### PR TITLE
fix: API fatal error handling & side panel placeholder cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,9 @@
             </div>
           </div>
         </div>
+        <p id="no-details-message" class="panel-section" style="display:none; color: var(--text-secondary); font-size: 0.8rem; font-style: italic;">
+          No detailed regulation data available for this country.
+        </p>
         <div class="panel-section" id="regulation-section">
           <div class="panel-section-label">REGULATION STATUS</div>
           <p id="regulation-details"></p>

--- a/map.js
+++ b/map.js
@@ -228,6 +228,18 @@ function showSection(id, show) {
   if (el) el.style.display = show ? '' : 'none';
 }
 
+const PLACEHOLDER_RE = /^(na|n\/a|idem|unknown|none|\s*[-–—]\s*|\.\s*)$/i;
+
+function cleanRegulationText(text) {
+  if (!text || typeof text !== 'string') return null;
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return null;
+  if (PLACEHOLDER_RE.test(trimmed)) return null;
+  if (/^(cf\.|Cf\.)\s/i.test(trimmed) && trimmed.length < 40) return null;
+  if (/^idem\b/i.test(trimmed) && trimmed.length < 10) return null;
+  return trimmed;
+}
+
 function updateCountryData(countryName, countryData, regulationData) {
   const scoreData = countryData[countryName];
   const regData = regulationData[countryName];
@@ -260,25 +272,35 @@ function updateCountryData(countryName, countryData, regulationData) {
   renderDots('dots-enforcement',scoreData ? scoreData.enforcementLevel : null);
 
   if (regData) {
-    document.getElementById('regulation-details').textContent = regData.regulationStatus || 'N/A';
-    document.getElementById('policy-details').textContent     = regData.policyLever || 'N/A';
-    document.getElementById('governance-details').textContent = regData.governanceType || 'N/A';
-    document.getElementById('actors-details').textContent     = regData.actorInvolvement || 'N/A';
+    const regText = cleanRegulationText(regData.regulationStatus);
+    const polText = cleanRegulationText(regData.policyLever);
+    const govText = cleanRegulationText(regData.governanceType);
+    const actText = cleanRegulationText(regData.actorInvolvement);
 
-    showSection('enforcement-section', !!regData.enforcementLevel);
-    if (regData.enforcementLevel) {
-      document.getElementById('enforcement-details').textContent = regData.enforcementLevel;
-    }
+    showSection('regulation-section', !!regText);
+    if (regText) document.getElementById('regulation-details').textContent = regText;
 
-    showSection('laws-section', !!regData.specificLaws);
-    if (regData.specificLaws) {
-      document.getElementById('specific-laws').textContent = regData.specificLaws;
-    }
+    showSection('policy-section', !!polText);
+    if (polText) document.getElementById('policy-details').textContent = polText;
+
+    showSection('governance-section', !!govText);
+    if (govText) document.getElementById('governance-details').textContent = govText;
+
+    showSection('actors-section', !!actText);
+    if (actText) document.getElementById('actors-details').textContent = actText;
+
+    const enfText = cleanRegulationText(regData.enforcementLevel);
+    showSection('enforcement-section', !!enfText);
+    if (enfText) document.getElementById('enforcement-details').textContent = enfText;
+
+    const lawsText = cleanRegulationText(regData.specificLaws);
+    showSection('laws-section', !!lawsText);
+    if (lawsText) document.getElementById('specific-laws').textContent = lawsText;
 
     const sourcesContainer = document.getElementById('sources-list');
     sourcesContainer.replaceChildren();
-    const urls = regData.sources && regData.sources !== 'NA'
-      ? regData.sources.split('|').map(u => u.trim()).filter(Boolean)
+    const urls = regData.sources
+      ? regData.sources.split('|').map(u => u.trim()).filter(u => u && !PLACEHOLDER_RE.test(u))
       : [];
     if (urls.length > 0) {
       urls.forEach((url, i) => {
@@ -296,13 +318,24 @@ function updateCountryData(countryName, countryData, regulationData) {
     } else {
       showSection('sources-section', false);
     }
+
+    const hasAnyDetail = regText || polText || govText || actText || enfText || lawsText || urls.length > 0;
+    document.getElementById('no-details-message').style.display = hasAnyDetail ? 'none' : '';
+
+    if (regData.confidence === 'low') {
+      document.querySelectorAll('#panel-content .panel-section').forEach(s => s.classList.add('low-quality'));
+    } else {
+      document.querySelectorAll('#panel-content .panel-section').forEach(s => s.classList.remove('low-quality'));
+    }
   } else {
-    ['regulation-details', 'policy-details', 'governance-details', 'actors-details'].forEach(id => {
-      document.getElementById(id).textContent = 'N/A';
-    });
+    showSection('regulation-section', false);
+    showSection('policy-section', false);
+    showSection('governance-section', false);
+    showSection('actors-section', false);
     showSection('enforcement-section', false);
     showSection('laws-section', false);
     showSection('sources-section', false);
+    document.getElementById('no-details-message').style.display = '';
   }
 }
 

--- a/scripts/update_data.py
+++ b/scripts/update_data.py
@@ -30,6 +30,11 @@ except ImportError:
     sys.exit(1)
 
 
+class FatalAPIError(Exception):
+    """Raised when the API returns an unrecoverable error."""
+    pass
+
+
 # ── Configuration ─────────────────────────────────────────────
 
 SCORES_CSV = "scores.csv"
@@ -216,6 +221,24 @@ def research_country(client, country, existing_reg, model):
     except json.JSONDecodeError as e:
         print(f"  WARNING: JSON parse error for {country}: {e}")
         return None
+    except anthropic.AuthenticationError as e:
+        raise FatalAPIError(f"Authentication failed (invalid API key): {e}")
+    except anthropic.PermissionDeniedError as e:
+        raise FatalAPIError(f"Permission denied (check credits/permissions): {e}")
+    except anthropic.RateLimitError as e:
+        print(f"  WARNING: Rate limited for {country}: {e}")
+        return None
+    except anthropic.APITimeoutError as e:
+        print(f"  WARNING: Timeout for {country}: {e}")
+        return None
+    except anthropic.APIConnectionError as e:
+        print(f"  WARNING: Connection error for {country}: {e}")
+        return None
+    except anthropic.APIStatusError as e:
+        if e.status_code >= 500:
+            print(f"  WARNING: Server error ({e.status_code}) for {country}: {e}")
+            return None
+        raise FatalAPIError(f"API error {e.status_code}: {e}")
     except Exception as e:
         print(f"  ERROR researching {country}: {e}")
         return None
@@ -341,75 +364,93 @@ def main():
 
     updated_count = 0
     failed_countries = []
+    consecutive_failures = 0
 
-    for i, country in enumerate(to_update, 1):
-        print(f"[{i}/{len(to_update)}] Researching {country}...")
-        result = research_country(client, country, reg_data.get(country), args.model)
+    try:
+        for i, country in enumerate(to_update, 1):
+            print(f"[{i}/{len(to_update)}] Researching {country}...")
+            result = research_country(client, country, reg_data.get(country), args.model)
 
-        if result is None:
-            failed_countries.append(country)
-            # Small backoff before continuing
-            time.sleep(2)
-            continue
+            if result is None:
+                failed_countries.append(country)
+                consecutive_failures += 1
+                if consecutive_failures >= 5:
+                    raise FatalAPIError(
+                        f"{consecutive_failures} consecutive failures — likely a systemic issue"
+                    )
+                time.sleep(2)
+                continue
 
-        # Calculate average score
-        score_fields = [
-            result.get("regulation_status_score"),
-            result.get("policy_lever_score"),
-            result.get("governance_type_score"),
-            result.get("actor_involvement_score"),
-        ]
-        valid_scores = [s for s in score_fields if s is not None]
-        avg_score = round(sum(valid_scores) / len(valid_scores), 2) if valid_scores else None
+            consecutive_failures = 0
 
-        result["average_score"] = avg_score
+            # Calculate average score
+            score_fields = [
+                result.get("regulation_status_score"),
+                result.get("policy_lever_score"),
+                result.get("governance_type_score"),
+                result.get("actor_involvement_score"),
+            ]
+            valid_scores = [s for s in score_fields if s is not None]
+            avg_score = round(sum(valid_scores) / len(valid_scores), 2) if valid_scores else None
 
-        # Get current data version
-        current_version = int(scores_data.get(country, {}).get("Data Version", 1) or 1)
+            result["average_score"] = avg_score
 
-        # Update scores dict
-        if country not in scores_data:
-            scores_data[country] = {"Country": country}
-        scores_data[country].update({
-            "Country": country,
-            "Regulation Status": result.get("regulation_status_score", ""),
-            "Policy Lever": result.get("policy_lever_score", ""),
-            "Governance Type": result.get("governance_type_score", ""),
-            "Actor Involvement": result.get("actor_involvement_score", ""),
-            "Average Score": avg_score or "",
-            "Enforcement Level": result.get("enforcement_level_score", ""),
-            "Last Updated": today_str,
-            "Data Version": current_version + 1,
-        })
+            # Get current data version
+            current_version = int(scores_data.get(country, {}).get("Data Version", 1) or 1)
 
-        # Update regulation dict
-        if country not in reg_data:
-            reg_data[country] = {"Country": country}
-        reg_data[country].update({
-            "Country": country,
-            "Regulation Status": result.get("regulation_status_text", ""),
-            "Policy Lever": result.get("policy_lever_text", ""),
-            "Governance Type": result.get("governance_type_text", ""),
-            "Actor Involvement": result.get("actor_involvement_text", ""),
-            "Enforcement Level": result.get("enforcement_level_text", ""),
-            "Specific Laws": result.get("specific_laws", ""),
-            "Sources": result.get("sources", ""),
-            "Last Updated": today_str,
-            "Confidence": result.get("confidence", "medium"),
-        })
+            # Update scores dict
+            if country not in scores_data:
+                scores_data[country] = {"Country": country}
+            scores_data[country].update({
+                "Country": country,
+                "Regulation Status": result.get("regulation_status_score", ""),
+                "Policy Lever": result.get("policy_lever_score", ""),
+                "Governance Type": result.get("governance_type_score", ""),
+                "Actor Involvement": result.get("actor_involvement_score", ""),
+                "Average Score": avg_score or "",
+                "Enforcement Level": result.get("enforcement_level_score", ""),
+                "Last Updated": today_str,
+                "Data Version": current_version + 1,
+            })
 
-        # Append to history
-        added = append_history_snapshot(history, country, result, today_str)
+            # Update regulation dict
+            if country not in reg_data:
+                reg_data[country] = {"Country": country}
+            reg_data[country].update({
+                "Country": country,
+                "Regulation Status": result.get("regulation_status_text", ""),
+                "Policy Lever": result.get("policy_lever_text", ""),
+                "Governance Type": result.get("governance_type_text", ""),
+                "Actor Involvement": result.get("actor_involvement_text", ""),
+                "Enforcement Level": result.get("enforcement_level_text", ""),
+                "Specific Laws": result.get("specific_laws", ""),
+                "Sources": result.get("sources", ""),
+                "Last Updated": today_str,
+                "Confidence": result.get("confidence", "medium"),
+            })
 
-        confidence = result.get("confidence", "?")
-        snapshot_note = "(new snapshot)" if added else "(no score change)"
-        print(f"  Done. Avg score: {avg_score}, Confidence: {confidence} {snapshot_note}")
+            # Append to history
+            added = append_history_snapshot(history, country, result, today_str)
 
-        updated_count += 1
+            confidence = result.get("confidence", "?")
+            snapshot_note = "(new snapshot)" if added else "(no score change)"
+            print(f"  Done. Avg score: {avg_score}, Confidence: {confidence} {snapshot_note}")
 
-        # Small delay to be polite to the API
-        if i < len(to_update):
-            time.sleep(0.5)
+            updated_count += 1
+
+            # Small delay to be polite to the API
+            if i < len(to_update):
+                time.sleep(0.5)
+
+    except FatalAPIError as e:
+        print(f"\nFATAL: {e}")
+        print(f"Aborting. {updated_count} countries updated before failure.")
+        if updated_count > 0:
+            print("Saving partial progress...")
+            write_scores(scores_data)
+            write_regulation(reg_data)
+            write_history(history)
+        sys.exit(2)
 
     # Validate before writing
     errors = validate_outputs(scores_data, reg_data)

--- a/style.css
+++ b/style.css
@@ -376,6 +376,11 @@ input[type="range"] {
   margin: 0;
 }
 
+.panel-section.low-quality p {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
 /* ── Score bar ─────────────────────────────────────────────── */
 .score-bar-row {
   display: flex;


### PR DESCRIPTION
## Summary
- **API error handling**: `research_country()` now catches specific anthropic SDK exceptions — fatal errors (401 auth, 403 credit/permission) abort immediately with partial progress saved, while transient errors (429 rate limit, timeouts, 5xx) continue the loop. A consecutive failure counter aborts after 5 failures in a row.
- **Side panel cleanup**: Placeholder text ("idem", "cf. African Union.", "NA", etc.) is detected and hidden. Sections with no meaningful data are collapsed, and a "No detailed regulation data available" fallback message appears when all sections are empty. Low-confidence countries get subtle italic styling.

## Test plan
- [ ] Run `python scripts/update_data.py --dry-run` to verify script still parses and runs
- [ ] Temporarily use an invalid API key — should exit immediately with "Authentication failed" message
- [ ] Open map in browser, click Somalia/Tunisia — placeholder text should be hidden, "no details" message shown
- [ ] Click China/Japan — real regulation text should display normally
- [ ] Verify low-confidence countries show italic styling in panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)