### PR TITLE
feat: add web search to Claude API calls and update default model

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -18,7 +18,7 @@ on:
       model:
         description: 'Claude model to use'
         required: false
-        default: 'claude-opus-4-5'
+        default: 'claude-sonnet-4-6'
 
 jobs:
   update-data:
@@ -44,7 +44,7 @@ jobs:
         run: |
           python scripts/update_data.py \
             --countries "${{ github.event.inputs.countries || '' }}" \
-            --model "${{ github.event.inputs.model || 'claude-opus-4-5' }}" \
+            --model "${{ github.event.inputs.model || 'claude-sonnet-4-6' }}" \
             ${{ (github.event.inputs.force_update == 'true') && '--force' || '' }}
 
       - name: Check for changes

--- a/scripts/update_data.py
+++ b/scripts/update_data.py
@@ -203,10 +203,15 @@ def research_country(client, country, existing_reg, model):
     try:
         response = client.messages.create(
             model=model,
-            max_tokens=1024,
+            max_tokens=2048,
+            tools=[{"type": "web_search_20250305", "name": "web_search"}],
             messages=[{"role": "user", "content": prompt}]
         )
-        text = response.content[0].text.strip()
+        text = next((block.text for block in response.content if block.type == "text"), None)
+        if not text:
+            print(f"  WARNING: no text block in response for {country}")
+            return None
+        text = text.strip()
         # Strip markdown code fences if present
         if text.startswith("```"):
             text = text.split("```")[1]
@@ -302,7 +307,7 @@ def main():
     parser.add_argument("--countries", default="", help="Comma-separated list of countries to update")
     parser.add_argument("--force", action="store_true", help="Force update regardless of staleness")
     parser.add_argument("--dry-run", action="store_true", help="Show what would change without writing")
-    parser.add_argument("--model", default="claude-opus-4-5", help="Claude model to use")
+    parser.add_argument("--model", default="claude-sonnet-4-6", help="Claude model to use")
     args = parser.parse_args()
 
     api_key = os.environ.get("ANTHROPIC_API_KEY")


### PR DESCRIPTION
## Summary
- Add web_search_20250305 tool to Claude API for current regulation research
- Bump max_tokens to 2048 to handle tool-augmented responses
- Fix response parsing to extract text block from mixed content types
- Update default model to claude-sonnet-4-6 (faster, more efficient)

## Changes
- `scripts/update_data.py`: Web search integration, response parsing fix
- `.github/workflows/update-data.yml`: Default model update