### PR TITLE
feat: citability and resilience — permalinks, cite action, methodology, loading/error states

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,17 @@
   <!-- General meta -->
   <meta name="description" content="Interactive map tracking AI governance and regulation status across every country. Scores, legislation, and policy details updated monthly.">
 
-  <!-- Resolve theme before paint to avoid a flash of wrong theme -->
+  <!-- Resolve theme before paint to avoid a flash of wrong theme.
+       URL wins over localStorage wins over prefers-color-scheme. -->
   <script>
     (function () {
       try {
+        var urlTheme = new URLSearchParams(location.search).get('theme');
+        if (urlTheme === 'light' || urlTheme === 'dark') {
+          document.documentElement.setAttribute('data-theme', urlTheme);
+          try { localStorage.setItem('theme', urlTheme); } catch (e) {}
+          return;
+        }
         var t = localStorage.getItem('theme');
         if (t === 'light' || t === 'dark') {
           document.documentElement.setAttribute('data-theme', t);
@@ -44,10 +51,31 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/style.min.css">
 </head>
 <body>
+  <noscript>
+    <div class="noscript-fallback">
+      <h1>AI Regulation Map</h1>
+      <p>
+        This site renders an interactive world map and requires JavaScript.
+        Without it, you can still:
+      </p>
+      <ul>
+        <li>read the <a href="/methodology.html">methodology page</a> (plain HTML, works offline)</li>
+        <li>browse the raw data on
+          <a href="https://github.com/riadeane/airegulationmap/tree/main/public" rel="noopener noreferrer">GitHub</a>
+          — `scores.csv`, `regulation_data.csv`, and monthly `history.json` snapshots.</li>
+      </ul>
+    </div>
+  </noscript>
   <a class="skip-link" href="#app-main">Skip to content</a>
   <header id="app-header">
     <div class="header-left">
       <h1>AI Regulation Map</h1>
+      <a
+        class="header-methodology-link"
+        href="/methodology.html"
+        aria-label="How countries are scored — methodology"
+        title="Methodology"
+      >?</a>
       <span class="header-subtitle">Last updated: <span id="site-last-updated">—</span></span>
       <span class="country-count-badge" id="country-count"></span>
     </div>
@@ -108,8 +136,20 @@
 
   <main id="app-main" aria-label="World map and country detail">
     <div id="map-wrapper">
-      <div id="map"></div>
+      <div id="map">
+        <div id="map-skeleton" aria-hidden="true">
+          <div class="map-skeleton-shimmer"></div>
+          <div class="map-skeleton-label">Loading regulation data…</div>
+        </div>
+      </div>
       <div id="zoom-controls"></div>
+      <div
+        id="map-live-region"
+        class="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      ></div>
     </div>
     <aside id="country-panel">
       <p id="no-selection-message">Select a country to see details.<br><span class="hint">Tip: Shift+click two or more countries to compare them.</span></p>
@@ -120,7 +160,24 @@
             <span id="confidence-badge" class="confidence-badge"></span>
           </div>
           <small id="last-updated" class="data-freshness"></small>
-          <button id="compare-btn" class="compare-btn" type="button">+ Compare</button>
+          <div class="panel-header-actions">
+            <button id="compare-btn" class="compare-btn" type="button">+ Compare</button>
+            <button
+              id="cite-btn"
+              class="cite-btn"
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="cite-popover"
+            >Cite</button>
+          </div>
+          <div
+            id="cite-popover"
+            class="cite-popover"
+            role="dialog"
+            aria-label="Copy citation"
+            hidden
+          ></div>
         </div>
         <div class="panel-section">
           <div class="panel-section-label">OVERALL SCORE</div>
@@ -214,6 +271,7 @@
 
   <footer>
     <p>Data sourced from the <a href="https://forum.effectivealtruism.org/posts/8tJbcAXDZKEqQXgyR/ai-governance-tracker-of-each-country-per-region" target="_blank" rel="noopener noreferrer">EA AI Governance Tracker</a>. Scores assigned by <a href="https://claude.ai/" target="_blank" rel="noopener noreferrer">Claude</a>. Updated monthly.</p>
+    <p>Methodology: <a href="/methodology.html">How countries are scored</a></p>
     <p>Made by Ria Deane &nbsp;&middot;&nbsp;
       <a href="https://www.linkedin.com/in/riadeane" target="_blank" rel="noopener noreferrer">LinkedIn</a> &nbsp;&middot;&nbsp;
       <a href="https://github.com/riadeane" target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/public/methodology.html
+++ b/public/methodology.html
@@ -1,0 +1,442 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Methodology — AI Regulation Map</title>
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="canonical" href="https://airegulationmap.org/methodology.html">
+
+  <meta name="description" content="How country scores on the AI Regulation Map are constructed, the 1–5 rubric for each dimension, confidence levels, update cadence, and known limitations.">
+
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Methodology — AI Regulation Map">
+  <meta property="og:description" content="The 1–5 rubric for scoring AI regulation across six dimensions, plus the pipeline that assigns and updates scores.">
+  <meta property="og:image" content="https://airegulationmap.org/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://airegulationmap.org/methodology.html">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Methodology — AI Regulation Map">
+  <meta name="twitter:description" content="How scores are constructed, the 1–5 rubric, and the automated pipeline.">
+  <meta name="twitter:image" content="https://airegulationmap.org/og-image.png">
+
+  <!-- Resolve theme before paint. URL > localStorage > prefers-color-scheme. -->
+  <script>
+    (function () {
+      try {
+        var urlTheme = new URLSearchParams(location.search).get('theme');
+        if (urlTheme === 'light' || urlTheme === 'dark') {
+          document.documentElement.setAttribute('data-theme', urlTheme);
+          return;
+        }
+        var t = localStorage.getItem('theme');
+        if (t === 'light' || t === 'dark') {
+          document.documentElement.setAttribute('data-theme', t);
+        }
+      } catch (e) { /* storage blocked */ }
+    })();
+  </script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;1,7..72,400&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/style.min.css">
+
+  <style>
+    /* Tokens — mirror of the main app's _tokens.css, trimmed to what
+       this page actually uses. Kept inline so methodology.html renders
+       correctly even if the main bundle is unavailable. */
+    :root {
+      --brand-hue: 75;
+      --radius: 8px;
+      --radius-sm: 5px;
+      --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+
+      --bg:              oklch(15% 0.008 var(--brand-hue));
+      --surface:         oklch(19% 0.009 var(--brand-hue));
+      --surface-raised:  oklch(23% 0.010 var(--brand-hue));
+      --border:          oklch(30% 0.013 var(--brand-hue));
+      --border-subtle:   oklch(24% 0.010 var(--brand-hue));
+
+      --text-primary:    oklch(92% 0.012 var(--brand-hue));
+      --text-secondary:  oklch(72% 0.014 var(--brand-hue));
+      --text-tertiary:   oklch(58% 0.014 var(--brand-hue));
+
+      --accent:          oklch(76% 0.13 var(--brand-hue));
+      --accent-muted:    oklch(76% 0.13 var(--brand-hue) / 0.14);
+
+      color-scheme: dark;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root:not([data-theme]) {
+        --bg:              oklch(98% 0.003 80);
+        --surface:         oklch(99.5% 0.002 80);
+        --surface-raised:  oklch(100% 0 0);
+        --border:          oklch(88% 0.008 80);
+        --border-subtle:   oklch(94% 0.004 80);
+        --text-primary:    oklch(20% 0.013 80);
+        --text-secondary:  oklch(42% 0.014 80);
+        --text-tertiary:   oklch(58% 0.014 80);
+        --accent:          oklch(48% 0.16 60);
+        --accent-muted:    oklch(48% 0.16 60 / 0.10);
+        color-scheme: light;
+      }
+    }
+
+    :root[data-theme='light'] {
+      --bg:              oklch(98% 0.003 80);
+      --surface:         oklch(99.5% 0.002 80);
+      --surface-raised:  oklch(100% 0 0);
+      --border:          oklch(88% 0.008 80);
+      --border-subtle:   oklch(94% 0.004 80);
+      --text-primary:    oklch(20% 0.013 80);
+      --text-secondary:  oklch(42% 0.014 80);
+      --text-tertiary:   oklch(58% 0.014 80);
+      --accent:          oklch(48% 0.16 60);
+      --accent-muted:    oklch(48% 0.16 60 / 0.10);
+      color-scheme: light;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Geist', -apple-system, sans-serif;
+      background: var(--bg);
+      color: var(--text-primary);
+      line-height: 1.65;
+      font-size: 15px;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; }
+    a:hover { filter: brightness(1.1); }
+
+    header.site-header {
+      padding: 18px 32px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: baseline;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    header.site-header a.site-title {
+      font-family: 'Literata', Georgia, serif;
+      font-size: 1.15rem;
+      font-weight: 500;
+      color: var(--text-primary);
+      text-decoration: none;
+      letter-spacing: -0.005em;
+    }
+
+    header.site-header a.site-title:hover { color: var(--accent); }
+
+    header.site-header nav {
+      color: var(--text-tertiary);
+      font-size: 0.78rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    header.site-header nav span { color: var(--text-primary); }
+
+    main.doc {
+      max-width: 68ch;
+      margin: 48px auto 96px;
+      padding: 0 28px;
+    }
+
+    h1.doc-title {
+      font-family: 'Literata', Georgia, serif;
+      font-size: 2.1rem;
+      font-weight: 400;
+      line-height: 1.15;
+      letter-spacing: -0.012em;
+      color: var(--text-primary);
+      margin-bottom: 8px;
+    }
+
+    p.doc-subtitle {
+      font-size: 0.95rem;
+      color: var(--text-secondary);
+      margin-bottom: 36px;
+      max-width: 54ch;
+    }
+
+    h2 {
+      font-family: 'Literata', Georgia, serif;
+      font-size: 1.35rem;
+      font-weight: 500;
+      letter-spacing: -0.005em;
+      color: var(--text-primary);
+      margin: 52px 0 10px;
+      scroll-margin-top: 24px;
+    }
+
+    h3 {
+      font-family: 'Geist', -apple-system, sans-serif;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--text-tertiary);
+      margin: 28px 0 8px;
+    }
+
+    p { color: var(--text-secondary); margin-bottom: 14px; }
+    p strong { color: var(--text-primary); font-weight: 500; }
+
+    ul, ol {
+      color: var(--text-secondary);
+      padding-left: 22px;
+      margin-bottom: 14px;
+    }
+
+    li { margin-bottom: 6px; }
+
+    .rubric {
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius);
+      overflow: hidden;
+      margin: 14px 0 20px;
+      font-size: 0.9rem;
+    }
+
+    .rubric-row {
+      display: grid;
+      grid-template-columns: 52px 1fr;
+      gap: 16px;
+      padding: 12px 16px;
+      border-top: 1px solid var(--border-subtle);
+    }
+
+    .rubric-row:first-child { border-top: 0; }
+
+    .rubric-score {
+      font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+      color: var(--accent);
+      font-variant-numeric: tabular-nums;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+    }
+
+    .rubric-body { color: var(--text-secondary); line-height: 1.55; }
+    .rubric-body em {
+      color: var(--text-tertiary);
+      font-style: italic;
+      display: block;
+      margin-top: 3px;
+      font-size: 0.82rem;
+    }
+
+    .callout {
+      background: var(--accent-muted);
+      border-radius: var(--radius-sm);
+      padding: 14px 20px;
+      margin: 20px 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    .callout strong {
+      display: block;
+      margin-bottom: 4px;
+      color: var(--text-primary);
+      font-family: 'Literata', Georgia, serif;
+      font-weight: 500;
+    }
+
+    code, pre {
+      font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+      font-size: 0.85em;
+      color: var(--text-primary);
+      background: var(--surface);
+      padding: 2px 6px;
+      border-radius: 3px;
+    }
+
+    pre {
+      padding: 14px 18px;
+      overflow-x: auto;
+      line-height: 1.5;
+      font-size: 0.82rem;
+    }
+
+    footer.site-footer {
+      border-top: 1px solid var(--border);
+      padding: 24px 32px;
+      color: var(--text-tertiary);
+      font-size: 0.8rem;
+      text-align: center;
+    }
+
+    /* Print — strip chrome, inline everything, use black-on-white. */
+    @media print {
+      body { background: white; color: black; font-size: 11pt; }
+      header.site-header, footer.site-footer { display: none; }
+      main.doc { max-width: none; margin: 0; padding: 0; }
+      h1.doc-title, h2, h3 { color: black; }
+      p, li { color: #222; }
+      a { color: black; text-decoration: none; }
+      a[href]::after { content: " (" attr(href) ")"; font-size: 0.85em; color: #555; }
+      .rubric { border-color: #bbb; }
+      .rubric-row { border-color: #ddd; }
+      .rubric-score { color: black; }
+      .callout { background: #f2f2f2; }
+    }
+
+    /* Respect user motion preference */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    :focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 3px;
+      border-radius: var(--radius-sm);
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a class="site-title" href="/">AI Regulation Map</a>
+    <nav aria-label="breadcrumb"><span>Methodology</span></nav>
+  </header>
+
+  <main class="doc">
+    <h1 class="doc-title">Methodology</h1>
+    <p class="doc-subtitle">
+      How country scores are constructed, what the numbers mean, and
+      what this tool can and cannot tell you.
+    </p>
+
+    <h2 id="what-this-is">What this is</h2>
+    <p>
+      The AI Regulation Map visualizes the current state of AI governance in
+      196 countries across six dimensions, each scored 1&ndash;5. It is
+      intended as a <em>reference view</em> for policy researchers, academics,
+      and civil society: a place to form a comparable mental model of how
+      different jurisdictions approach AI, and a jumping-off point to the
+      primary sources behind each score.
+    </p>
+
+    <div class="callout">
+      <strong>Epistemic caveat.</strong> Scores are inferred by
+      <a href="https://claude.ai/" rel="noopener noreferrer">Claude</a>
+      from public sources and refreshed monthly. They are not produced by
+      human coders and have not been independently audited. Treat them
+      the way you would treat a well-read colleague's summary: useful
+      for orientation, worth verifying before citation.
+    </div>
+
+    <h2 id="the-six-dimensions">The six dimensions</h2>
+    <p>
+      Each country is scored on six dimensions. Five of them describe
+      <em>how</em> regulation operates; the sixth (<strong>average
+      score</strong>) is their mean, shown by default.
+    </p>
+
+    <h3>Regulation Status</h3>
+    <p>The existence and maturity of AI-specific regulation — whether binding law, a draft bill, a national strategy, or nothing at all.</p>
+    <div class="rubric">
+      <div class="rubric-row"><div class="rubric-score">1</div><div class="rubric-body">No regulation or minimal engagement; AI is not named in policy documents. <em>Example: many least-developed countries with no ICT ministry position on AI.</em></div></div>
+      <div class="rubric-row"><div class="rubric-score">2</div><div class="rubric-body">Early-stage engagement: voluntary guidelines, a sectoral code of practice, or an advisory committee. <em>Example: a national ethics advisory board with non-binding recommendations.</em></div></div>
+      <div class="rubric-row"><div class="rubric-score">3</div><div class="rubric-body">National strategy or draft legislation in progress; public consultation underway. <em>Example: a published national AI strategy without enabling legislation.</em></div></div>
+      <div class="rubric-row"><div class="rubric-score">4</div><div class="rubric-body">Active, enacted AI regulation covering a substantial slice of deployment contexts. <em>Example: a jurisdiction with binding sector-specific AI rules (finance, health).</em></div></div>
+      <div class="rubric-row"><div class="rubric-score">5</div><div class="rubric-body">Comprehensive, binding, cross-sector AI regulation with explicit enforcement mechanisms. <em>Example: the EU under the AI Act.</em></div></div>
+    </div>
+
+    <h3>Policy Lever</h3>
+    <p>The breadth of policy instruments in use — from narrow, sector-specific tools to broad, cross-cutting frameworks.</p>
+    <div class="rubric">
+      <div class="rubric-row"><div class="rubric-score">1</div><div class="rubric-body">Narrow: one tool, one sector, or indirect leverage only (e.g. data protection law being bent to cover AI).</div></div>
+      <div class="rubric-row"><div class="rubric-score">3</div><div class="rubric-body">Mixed: several instruments — standards, procurement guidance, R&amp;D funding, some sectoral rules.</div></div>
+      <div class="rubric-row"><div class="rubric-score">5</div><div class="rubric-body">Broad: a horizontal regulatory framework plus sectoral adaptations, public investment, and compliance infrastructure.</div></div>
+    </div>
+
+    <h3>Governance Type</h3>
+    <p>Where authority for AI regulation sits — concentrated in a single body vs. distributed across agencies, sectors, and levels of government.</p>
+    <div class="rubric">
+      <div class="rubric-row"><div class="rubric-score">1</div><div class="rubric-body">Centralized: a single national authority sets and enforces policy.</div></div>
+      <div class="rubric-row"><div class="rubric-score">3</div><div class="rubric-body">Hybrid: a lead body coordinates with sectoral regulators or sub-national jurisdictions.</div></div>
+      <div class="rubric-row"><div class="rubric-score">5</div><div class="rubric-body">Distributed: authority is spread across independent regulators, courts, and sub-national governments; coordination is emergent rather than imposed.</div></div>
+    </div>
+
+    <h3>Actor Involvement</h3>
+    <p>Which actors shape AI policy — narrow expert circles vs. broad engagement with industry, civil society, academia, and the public.</p>
+    <div class="rubric">
+      <div class="rubric-row"><div class="rubric-score">1</div><div class="rubric-body">Limited: policy is set inside government with minimal external input.</div></div>
+      <div class="rubric-row"><div class="rubric-score">3</div><div class="rubric-body">Consultative: published consultations, industry working groups, some academic input.</div></div>
+      <div class="rubric-row"><div class="rubric-score">5</div><div class="rubric-body">Broad: structured multi-stakeholder processes including civil society, trade unions, and international partners.</div></div>
+    </div>
+
+    <h3>Enforcement Level</h3>
+    <p>How strictly existing rules are enforced — from rules on paper only, to active supervision with penalties.</p>
+    <div class="rubric">
+      <div class="rubric-row"><div class="rubric-score">1</div><div class="rubric-body">No enforcement mechanism; obligations are not tied to any authority.</div></div>
+      <div class="rubric-row"><div class="rubric-score">3</div><div class="rubric-body">Soft enforcement: oversight bodies exist but audits and penalties are rare.</div></div>
+      <div class="rubric-row"><div class="rubric-score">5</div><div class="rubric-body">Active enforcement: penalties have been issued, audits are routine, and a dedicated authority publishes enforcement actions.</div></div>
+    </div>
+
+    <h3>Average Score</h3>
+    <p>The arithmetic mean of the five substantive dimensions above. Shown by default on the map because it gives the fastest cross-country read, but the individual dimensions are where the interesting signal lives.</p>
+
+    <h2 id="confidence">Confidence levels</h2>
+    <p>Each country record carries a confidence label that reflects how much public, primary evidence was available to the research pass.</p>
+    <ul>
+      <li><strong>High</strong> — scores are supported by enacted legislation, official regulator publications, and at least two independent English-language sources published within the last 12 months.</li>
+      <li><strong>Medium</strong> — scores rely on strategy documents, draft bills, or reputable secondary reporting; some dimensions may be inferred from adjacent policy areas.</li>
+      <li><strong>Low</strong> — public information is sparse, in a non-English primary language with uncertain translation, or predates the last major policy cycle. Treat these rows as indicative rather than definitive.</li>
+    </ul>
+    <p>Confidence is currently assigned at the record level (per country), not per individual dimension. We consider per-field confidence a future enhancement.</p>
+
+    <h2 id="update-cadence">Data update cadence</h2>
+    <p>A <a href="https://github.com/riadeane/airegulationmap/blob/main/.github/workflows/update-data.yml" rel="noopener noreferrer">GitHub Action</a> runs on the 1st of each month and researches any country whose record is older than a staleness threshold or flagged as low confidence. Manual overrides (single-country re-research, forced refresh of the whole dataset) are possible via <code>scripts/update_data.py</code>.</p>
+    <p>Every month's run is preserved as a snapshot in <code>public/history.json</code>, which drives the timeline slider on the main page — so the "score at date X" view is always reproducible from the raw data.</p>
+
+    <h2 id="limitations">Known limitations</h2>
+    <ul>
+      <li><strong>Point-in-time view.</strong> Scores reflect the state of regulation at the last research pass. Fast-moving jurisdictions can change materially between updates.</li>
+      <li><strong>English-source bias.</strong> Non-English primary sources are under-represented, which systematically disadvantages countries whose regulatory debates happen in other languages. Claude mitigates this but does not eliminate it.</li>
+      <li><strong>Aggregate hides regional variance.</strong> Federations (US, India, Brazil) are scored at the national level; substantial sub-national variation is flattened.</li>
+      <li><strong>Draft vs. enacted.</strong> The rubric tries to distinguish these, but a bill that passes the week after a research pass will not update until the next monthly run.</li>
+      <li><strong>No independent audit.</strong> Scores are LLM-inferred, not human-coded, and have not been audited by domain experts.</li>
+    </ul>
+
+    <h2 id="citing">Citing this site</h2>
+    <p>
+      Every view on the site &mdash; a single country, a comparison set, a
+      historic date, a specific score dimension &mdash; has a stable
+      permalink encoded in the URL query string. Include that permalink in
+      your citation so readers can reproduce the exact view.
+    </p>
+    <p>Suggested formats:</p>
+    <ul>
+      <li><strong>APA (7th).</strong> Deane, R. (2026). <em>AI Regulation Map</em> [Data visualization]. Retrieved YYYY-MM-DD, from https://airegulationmap.org/…</li>
+      <li><strong>Chicago (author-date).</strong> Deane, Ria. 2026. "AI Regulation Map." Accessed YYYY-MM-DD. https://airegulationmap.org/…</li>
+      <li><strong>MLA (9th).</strong> Deane, Ria. "AI Regulation Map." <em>AI Regulation Map</em>, 2026, https://airegulationmap.org/…. Accessed DD Mon. YYYY.</li>
+    </ul>
+    <p>The in-app "Cite" button on any country panel generates these strings for the current view and copies them to your clipboard.</p>
+
+    <h2 id="source">Source code and contact</h2>
+    <p>
+      The site is open source at
+      <a href="https://github.com/riadeane/airegulationmap" rel="noopener noreferrer">github.com/riadeane/airegulationmap</a>.
+      Issues and pull requests welcome. Made by
+      <a href="https://www.linkedin.com/in/riadeane" rel="noopener noreferrer">Ria Deane</a>.
+    </p>
+  </main>
+
+  <footer class="site-footer">
+    <p><a href="/">&larr; Back to the map</a></p>
+  </footer>
+</body>
+</html>

--- a/src/controls/citation.js
+++ b/src/controls/citation.js
@@ -1,0 +1,54 @@
+// Formatted citation strings (APA / Chicago / MLA) for the current
+// view. The `url` argument is the permalink so a reader can reproduce
+// the exact view the researcher cited.
+
+import { ATTRIBUTE_LABELS } from '../constants.js';
+
+const DEFAULT_MODE = 'averageScore';
+
+function viewTitle({ country, compareCountries, mode }) {
+  let title = 'AI Regulation Map';
+  if (compareCountries && compareCountries.length >= 2) {
+    title += ' \u2014 ' + compareCountries.join(', ') + ' comparison';
+  } else if (country) {
+    title += ' \u2014 ' + country;
+  }
+  if (mode && mode !== DEFAULT_MODE) {
+    title += ' (' + (ATTRIBUTE_LABELS[mode] || mode) + ')';
+  }
+  return title;
+}
+
+function humanAccessed(dateIso) {
+  // "17 April 2026" — Chicago / MLA prefer day-month-year.
+  const d = new Date(dateIso + 'T00:00:00');
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+// Produce APA / Chicago / MLA citations for the supplied view. The
+// `accessed` parameter is injected for tests; callers just pass the
+// live `url`.
+export function citationsFor({
+  country,
+  compareCountries,
+  mode,
+  timelineDate,
+  url,
+  accessed = new Date().toISOString().slice(0, 10),
+}) {
+  const year = (timelineDate || accessed).slice(0, 4);
+  const title = viewTitle({ country, compareCountries, mode });
+
+  // APA 7th: initial for first name; italicized title (not conveyed
+  // here since this is a plain-text string, but a reader can italicize
+  // the portion between "AI Regulation Map" and the final period).
+  const apa = `Deane, R. (${year}). ${title} [Data visualization]. Retrieved ${accessed}, from ${url}`;
+
+  // Chicago author-date.
+  const chicago = `Deane, Ria. ${year}. "${title}." Accessed ${humanAccessed(accessed)}. ${url}.`;
+
+  // MLA 9th.
+  const mla = `Deane, Ria. "${title}." AI Regulation Map, ${year}, ${url}. Accessed ${humanAccessed(accessed)}.`;
+
+  return { apa, chicago, mla };
+}

--- a/src/controls/citePopover.js
+++ b/src/controls/citePopover.js
@@ -1,0 +1,160 @@
+// "Cite" popover anchored under the panel's Cite button.
+//
+// Not a modal — a lightweight dismissable popover that shows three
+// formatted citation strings (APA / Chicago / MLA) with per-format
+// copy buttons. The permalink embedded in each citation is generated
+// fresh every open so scoped views stay citeable.
+
+import { getState, on } from '../state/store.js';
+import { citationsFor } from './citation.js';
+import { buildPermalink } from './url.js';
+
+const FORMATS = [
+  { key: 'apa', label: 'APA' },
+  { key: 'chicago', label: 'Chicago' },
+  { key: 'mla', label: 'MLA' },
+];
+
+let popoverEl;
+let buttonEl;
+let isOpen = false;
+
+function removeAllChildren(node) {
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+async function copyToClipboard(text, confirmBtn) {
+  const original = confirmBtn.textContent;
+  let success = false;
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      success = true;
+    } else {
+      // Fallback for non-HTTPS (e.g. preview servers). Ephemeral
+      // textarea + execCommand is deprecated but still broadly
+      // supported and works when the Clipboard API isn't available.
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.setAttribute('readonly', '');
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      success = document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+  } catch (e) {
+    console.warn('[cite] copy failed', e);
+  }
+
+  confirmBtn.textContent = success ? 'Copied \u2713' : 'Copy failed';
+  confirmBtn.classList.toggle('copied', success);
+  setTimeout(() => {
+    confirmBtn.textContent = original;
+    confirmBtn.classList.remove('copied');
+  }, 1500);
+}
+
+function renderRows() {
+  const state = getState();
+  const url = buildPermalink(state);
+  const citations = citationsFor({
+    country: state.selectedCountry,
+    compareCountries: state.comparisonCountries,
+    mode: state.currentAttribute,
+    timelineDate: state.timelineDate,
+    url,
+  });
+
+  removeAllChildren(popoverEl);
+
+  const heading = document.createElement('p');
+  heading.className = 'cite-popover-heading';
+  heading.textContent = 'Copy a formatted citation for this view';
+  popoverEl.appendChild(heading);
+
+  for (const { key, label } of FORMATS) {
+    const row = document.createElement('div');
+    row.className = 'cite-row';
+
+    const header = document.createElement('div');
+    header.className = 'cite-row-header';
+
+    const formatLabel = document.createElement('span');
+    formatLabel.className = 'cite-format';
+    formatLabel.textContent = label;
+
+    const copyBtn = document.createElement('button');
+    copyBtn.type = 'button';
+    copyBtn.className = 'cite-copy';
+    copyBtn.textContent = 'Copy';
+    copyBtn.addEventListener('click', () => copyToClipboard(citations[key], copyBtn));
+
+    header.appendChild(formatLabel);
+    header.appendChild(copyBtn);
+
+    const block = document.createElement('code');
+    block.className = 'cite-block';
+    block.textContent = citations[key];
+
+    row.appendChild(header);
+    row.appendChild(block);
+    popoverEl.appendChild(row);
+  }
+}
+
+function openPopover() {
+  if (!popoverEl || !buttonEl) return;
+  renderRows();
+  popoverEl.hidden = false;
+  buttonEl.setAttribute('aria-expanded', 'true');
+  isOpen = true;
+
+  // Dismiss on outside click / Escape. Bound in a microtask so the
+  // opening click itself doesn't immediately close it.
+  setTimeout(() => {
+    document.addEventListener('click', onDocClick);
+    document.addEventListener('keydown', onDocKey);
+  }, 0);
+}
+
+function closePopover() {
+  if (!popoverEl) return;
+  popoverEl.hidden = true;
+  if (buttonEl) buttonEl.setAttribute('aria-expanded', 'false');
+  isOpen = false;
+  document.removeEventListener('click', onDocClick);
+  document.removeEventListener('keydown', onDocKey);
+}
+
+function onDocClick(e) {
+  if (!isOpen) return;
+  if (popoverEl.contains(e.target)) return;
+  if (buttonEl && buttonEl.contains(e.target)) return;
+  closePopover();
+}
+
+function onDocKey(e) {
+  if (e.key === 'Escape') closePopover();
+}
+
+export function initCitePopover() {
+  buttonEl = document.getElementById('cite-btn');
+  popoverEl = document.getElementById('cite-popover');
+  if (!buttonEl || !popoverEl) return;
+
+  buttonEl.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (isOpen) closePopover();
+    else openPopover();
+  });
+
+  // Re-render in place if the state changes while the popover is open
+  // (e.g. user clicks a country in comparison mode without closing).
+  const rerenderIfOpen = () => { if (isOpen) renderRows(); };
+  on('selectedCountry', rerenderIfOpen);
+  on('comparisonCountries', rerenderIfOpen);
+  on('currentAttribute', rerenderIfOpen);
+  on('timelineDate', rerenderIfOpen);
+}

--- a/src/controls/scoreSelector.js
+++ b/src/controls/scoreSelector.js
@@ -13,6 +13,12 @@ export function buildScoreSelector() {
   const btn = document.getElementById('score-btn');
   const dropdown = document.getElementById('score-dropdown');
 
+  // Set initial button label from state so a URL-provided `?mode=` or
+  // a future persisted preference shows up correctly without a click.
+  const { currentAttribute } = getState();
+  document.getElementById('score-btn-label').textContent =
+    ATTRIBUTE_LABELS[currentAttribute] || ATTRIBUTE_LABELS.averageScore;
+
   for (const opt of SCORE_OPTIONS) {
     const li = document.createElement('li');
     li.textContent = opt.text;

--- a/src/controls/timeline.js
+++ b/src/controls/timeline.js
@@ -1,6 +1,19 @@
-import { getState } from '../state/store.js';
+import { getState, setState, on } from '../state/store.js';
 import { updateMap } from '../map/index.js';
 import { buildScoresAtDate, extractSortedDates } from '../data/history.js';
+
+// Module-scope so the map subscription (added in initTimeline) can
+// resolve `timelineDate` → historic scores without re-reading history.
+let historyRef = null;
+let sortedDatesRef = [];
+
+// Resolve the state's `timelineDate` to the actual scores to render.
+// Null / absent / "latest" dates map to the current scoreData.
+function scoresForDate(date) {
+  if (!date || !historyRef) return undefined;
+  if (!sortedDatesRef.includes(date)) return undefined;
+  return buildScoresAtDate(historyRef, date);
+}
 
 export function initTimeline(history) {
   if (!history) return;
@@ -8,25 +21,64 @@ export function initTimeline(history) {
   const sortedDates = extractSortedDates(history);
   if (sortedDates.length <= 1) return;
 
+  historyRef = history;
+  sortedDatesRef = sortedDates;
+
   const container = document.getElementById('timeline-strip');
   container.style.display = 'block';
 
   const slider = document.getElementById('timeline-slider');
   slider.max = sortedDates.length - 1;
-  slider.value = sortedDates.length - 1;
 
   const dateLabel = document.getElementById('timeline-date-label');
 
+  // Position the slider based on initial state — URL may have supplied
+  // a `date` param before we got here. If the URL's date isn't in the
+  // snapshot list, fall back to latest rather than erroring.
+  const { timelineDate: initialDate } = getState();
+  let initialIdx = sortedDates.length - 1;
+  if (initialDate) {
+    const i = sortedDates.indexOf(initialDate);
+    if (i >= 0) initialIdx = i;
+    else setState({ timelineDate: null }); // sanitize unknown date
+  }
+  slider.value = initialIdx;
+  dateLabel.textContent = initialIdx === sortedDates.length - 1 ? 'Latest' : sortedDates[initialIdx];
+
+  // If we loaded in on a historic date, kick a re-render now. The map
+  // subscription (below) would only fire on *changes*, so the initial
+  // paint still shows latest scores without this.
+  if (initialDate && sortedDates.includes(initialDate)) {
+    updateMap(scoresForDate(initialDate));
+  }
+
   slider.addEventListener('input', function () {
-    const selectedDate = sortedDates[parseInt(this.value)];
-    dateLabel.textContent = selectedDate;
-    const historicScores = buildScoresAtDate(history, selectedDate);
-    updateMap(historicScores);
+    const idx = parseInt(this.value);
+    const isLatest = idx === sortedDates.length - 1;
+    const selectedDate = sortedDates[idx];
+    dateLabel.textContent = isLatest ? 'Latest' : selectedDate;
+    setState({ timelineDate: isLatest ? null : selectedDate });
   });
 
   document.getElementById('timeline-reset').addEventListener('click', () => {
     slider.value = sortedDates.length - 1;
     dateLabel.textContent = 'Latest';
-    updateMap();
+    setState({ timelineDate: null });
+  });
+
+  // Any change to `timelineDate` (slider, reset, popstate, URL load)
+  // re-renders the map. The slider input handler itself doesn't need
+  // to call updateMap — this subscription is the single write seam.
+  on('timelineDate', (date) => {
+    updateMap(scoresForDate(date));
+
+    // Also keep the slider position and label in sync when the change
+    // comes from elsewhere (popstate / URL). The input handler would
+    // otherwise read its own value as stale on external writes.
+    const idx = date ? sortedDates.indexOf(date) : sortedDates.length - 1;
+    if (idx >= 0 && parseInt(slider.value) !== idx) {
+      slider.value = idx;
+      dateLabel.textContent = idx === sortedDates.length - 1 ? 'Latest' : sortedDates[idx];
+    }
   });
 }

--- a/src/controls/url.js
+++ b/src/controls/url.js
@@ -1,0 +1,167 @@
+// Shareable URLs.
+//
+// Every meaningful view the user lands on encodes to a query string so
+// a researcher can paste the URL into an email and the recipient sees
+// the same country, score dimension, comparison set, timeline date,
+// and theme.
+//
+// The store is the seam: state changes write to the URL via
+// `history.replaceState`, and `popstate` writes back into the store.
+// Defaults are omitted from the URL to keep links short.
+
+import { getState, setState, on } from '../state/store.js';
+import { SCORE_OPTIONS } from '../constants.js';
+import { MAX_COMPARISON } from '../comparison/index.js';
+
+const VALID_MODES = new Set(SCORE_OPTIONS.map(o => o.value));
+const DEFAULT_MODE = 'averageScore';
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function splitCompare(raw) {
+  if (!raw) return [];
+  const seen = new Set();
+  const out = [];
+  for (const part of raw.split(',')) {
+    const name = part.trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    out.push(name);
+    if (out.length >= MAX_COMPARISON) break;
+  }
+  return out;
+}
+
+// Parse the current window URL into a partial state object. Only keys
+// actually present in the URL appear in the returned object — callers
+// decide which defaults to apply.
+export function parseUrl(search = window.location.search) {
+  const params = new URLSearchParams(search);
+  const out = {};
+
+  const country = params.get('country');
+  if (country) out.country = decodeURIComponent(country);
+
+  const mode = params.get('mode');
+  if (mode && VALID_MODES.has(mode)) out.mode = mode;
+
+  const compare = params.get('compare');
+  if (compare) {
+    const list = splitCompare(decodeURIComponent(compare));
+    if (list.length > 0) out.compare = list;
+  }
+
+  const date = params.get('date');
+  if (date && ISO_DATE_RE.test(date)) out.date = date;
+
+  const theme = params.get('theme');
+  if (theme === 'light' || theme === 'dark') out.theme = theme;
+
+  return out;
+}
+
+// Build a query string from the current (or supplied) state. Omits any
+// key whose value matches the app default so the URL stays short.
+export function buildPermalink(stateSnapshot) {
+  const s = stateSnapshot || getState();
+  const params = new URLSearchParams();
+
+  if (s.comparisonCountries && s.comparisonCountries.length > 0) {
+    params.set('compare', s.comparisonCountries.join(','));
+  } else if (s.selectedCountry) {
+    params.set('country', s.selectedCountry);
+  }
+
+  if (s.currentAttribute && s.currentAttribute !== DEFAULT_MODE) {
+    params.set('mode', s.currentAttribute);
+  }
+
+  if (s.timelineDate) {
+    params.set('date', s.timelineDate);
+  }
+
+  const theme = document.documentElement.getAttribute('data-theme');
+  if (theme === 'light' || theme === 'dark') {
+    params.set('theme', theme);
+  }
+
+  // URLSearchParams percent-encodes commas (%2C). We want readable
+  // permalinks, so swap those back to literal commas in the final
+  // string — browsers accept both on parse.
+  const qs = params.toString().replace(/%2C/g, ',');
+  const url = window.location.pathname + (qs ? '?' + qs : '');
+  // Absolute URL for citations / sharing.
+  return window.location.origin + url;
+}
+
+function currentQueryString() {
+  const link = buildPermalink();
+  const i = link.indexOf('?');
+  return i >= 0 ? link.slice(i) : '';
+}
+
+// Replace the URL without adding a history entry. Used for hovers and
+// click-style navigation inside the app (Back should not undo a country
+// selection or score-mode flip — too chatty).
+function writeReplace() {
+  const qs = currentQueryString();
+  const next = window.location.pathname + qs;
+  const current = window.location.pathname + window.location.search;
+  if (next === current) return;
+  window.history.replaceState(null, '', next);
+}
+
+function applyUrlState(urlState, { initial = false } = {}) {
+  if (urlState.theme) {
+    document.documentElement.setAttribute('data-theme', urlState.theme);
+    try { localStorage.setItem('theme', urlState.theme); } catch (e) { /* storage blocked */ }
+  }
+
+  if (urlState.mode) setState({ currentAttribute: urlState.mode });
+  else if (!initial) setState({ currentAttribute: DEFAULT_MODE });
+
+  if (urlState.date !== undefined) setState({ timelineDate: urlState.date || null });
+  else if (!initial) setState({ timelineDate: null });
+
+  // Comparison wins over country — the comparison panel takes the
+  // right-hand slot either way.
+  const { scoreData } = getState();
+  const validCountry = (name) => !!scoreData[name];
+
+  if (urlState.compare && urlState.compare.length > 0) {
+    const valid = urlState.compare.filter(validCountry);
+    setState({ comparisonCountries: valid });
+    if (valid.length === 1) setState({ selectedCountry: valid[0] });
+  } else {
+    setState({ comparisonCountries: [] });
+    if (urlState.country && validCountry(urlState.country)) {
+      setState({ selectedCountry: urlState.country });
+    } else if (!initial) {
+      setState({ selectedCountry: null });
+    }
+  }
+}
+
+// Subscribe to the relevant state slices and keep the URL in sync with
+// the view the user is looking at.
+export function initUrlSync() {
+  on('selectedCountry', writeReplace);
+  on('comparisonCountries', writeReplace);
+  on('currentAttribute', writeReplace);
+  on('timelineDate', writeReplace);
+
+  // Theme changes come from two sources: the toggle (sets data-theme
+  // directly) and prefers-color-scheme. We watch the attribute.
+  const observer = new MutationObserver((records) => {
+    for (const r of records) {
+      if (r.type === 'attributes' && r.attributeName === 'data-theme') {
+        writeReplace();
+        return;
+      }
+    }
+  });
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+  window.addEventListener('popstate', () => {
+    applyUrlState(parseUrl());
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,9 @@ import { initFilter } from './controls/filter.js';
 import { initSearch, initKeyboardNav } from './controls/search.js';
 import { initTimeline } from './controls/timeline.js';
 import { initTheme } from './controls/theme.js';
+import { parseUrl, initUrlSync } from './controls/url.js';
+import { initCitePopover } from './controls/citePopover.js';
+import { removeMapSkeleton, showLoadError } from './panel/resilience.js';
 
 function updateSiteLastUpdated(scoreData) {
   const dates = Object.values(scoreData)
@@ -39,13 +42,31 @@ function closeAllDropdowns(e) {
 }
 
 async function main() {
-  const [scoreData, regulationData] = await Promise.all([
-    loadScores(),
-    loadRegulation(),
-  ]);
+  let scoreData, regulationData;
+  try {
+    [scoreData, regulationData] = await Promise.all([
+      loadScores(),
+      loadRegulation(),
+    ]);
+  } catch (err) {
+    showLoadError(err);
+    return;
+  }
 
   const sortedCountryNames = Object.keys(scoreData).sort();
   setState({ scoreData, regulationData, sortedCountryNames });
+
+  // Apply URL state BEFORE first render so `currentAttribute` and
+  // `timelineDate` land correctly on initial paint. Theme was already
+  // applied pre-paint by the inline script in index.html; we re-apply
+  // here only so `initTheme()` sees a consistent localStorage value.
+  const urlState = parseUrl();
+  if (urlState.theme) {
+    document.documentElement.setAttribute('data-theme', urlState.theme);
+    try { localStorage.setItem('theme', urlState.theme); } catch (e) { /* storage blocked */ }
+  }
+  if (urlState.mode) setState({ currentAttribute: urlState.mode });
+  if (urlState.date) setState({ timelineDate: urlState.date });
 
   // Wire up UI controls
   initTheme();
@@ -53,13 +74,31 @@ async function main() {
   initFilter();
   initDimensionClicks();
   initPanel();
+  initCitePopover();
   initComparison();
   initSearch();
   initKeyboardNav();
   initMapSubscriptions();
 
   // Render map
-  await generateMap();
+  try {
+    await generateMap();
+    removeMapSkeleton();
+  } catch (err) {
+    showLoadError(err);
+    return;
+  }
+
+  // Country / comparison selection needs the map to exist so the
+  // highlight fires correctly. Unknown country names (typo, deleted
+  // from data) are dropped silently.
+  if (urlState.compare && urlState.compare.length > 0) {
+    const valid = urlState.compare.filter(name => scoreData[name]);
+    if (valid.length > 0) setState({ comparisonCountries: valid });
+    if (valid.length === 1) setState({ selectedCountry: valid[0] });
+  } else if (urlState.country && scoreData[urlState.country]) {
+    setState({ selectedCountry: urlState.country });
+  }
 
   // Header info
   updateSiteLastUpdated(scoreData);
@@ -67,6 +106,10 @@ async function main() {
 
   // Load history non-blocking
   loadHistory().then(history => initTimeline(history));
+
+  // Start writing URL changes. Done after initial state is applied so
+  // we don't clobber the user's URL on boot.
+  initUrlSync();
 
   // Global click-away to close dropdowns
   document.addEventListener('click', closeAllDropdowns);

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -1,14 +1,29 @@
-import { on } from '../state/store.js';
+import { on, getState } from '../state/store.js';
 import { generateMap, updateMap } from './renderer.js';
 import { updateLegendLabels } from './legend.js';
+import { ATTRIBUTE_LABELS, LEGEND_ENDPOINTS } from '../constants.js';
 
 export { updateMap, highlightCountry, clearHighlight, updateSearchHighlight, markComparisonCountries } from './renderer.js';
 export { generateMap };
+
+// Speak the current map mode to assistive tech when it changes. The
+// region is polite — it waits for a lull in the user's focus rather
+// than interrupting mid-reading. aria-atomic ensures the whole
+// message is re-read on every update (not just the diff).
+function announceMode() {
+  const region = document.getElementById('map-live-region');
+  if (!region) return;
+  const { currentAttribute } = getState();
+  const label = ATTRIBUTE_LABELS[currentAttribute] || currentAttribute;
+  const [low, high] = LEGEND_ENDPOINTS[currentAttribute] || ['low', 'high'];
+  region.textContent = `Map now showing ${label}. Legend ranges from ${low} to ${high}.`;
+}
 
 export function initMapSubscriptions() {
   on('currentAttribute', () => {
     updateMap();
     updateLegendLabels();
+    announceMode();
   });
 
   on('filterMin', () => updateMap());

--- a/src/map/renderer.js
+++ b/src/map/renderer.js
@@ -96,10 +96,16 @@ export async function generateMap() {
 
   const svg = select('#map')
     .append('svg')
+    .attr('role', 'img')
+    .attr('aria-label', 'World map showing AI regulation scores by country. Click a country for details; Shift+click to compare.')
     .attr('width', size.w)
     .attr('height', size.h)
     .attr('viewBox', [0, 0, size.w, size.h])
     .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  // Some screen readers prefer <title> to aria-label on SVG, so set
+  // both. The title must be the first child to be announced correctly.
+  svg.append('title').text('World map showing AI regulation scores by country');
 
   svg.append('defs')
     .append('clipPath')

--- a/src/panel/index.js
+++ b/src/panel/index.js
@@ -4,6 +4,19 @@ import { renderTextSections } from './sections.js';
 import { highlightCountry, clearHighlight } from '../map/index.js';
 import { toggleComparison, MAX_COMPARISON } from '../comparison/index.js';
 
+const CONFIDENCE_LABELS = {
+  high: 'High confidence',
+  medium: 'Medium confidence',
+  low: 'Low confidence',
+};
+
+function normalizeConfidence(raw) {
+  if (!raw) return null;
+  const v = String(raw).trim().toLowerCase();
+  if (v === 'high' || v === 'medium' || v === 'low') return v;
+  return null;
+}
+
 function updateDimensionHighlight() {
   const { currentAttribute } = getState();
   document.querySelectorAll('.dimension-row[data-dimension]').forEach(row => {
@@ -36,6 +49,15 @@ function updateCompareButton() {
   }
 }
 
+function updateCiteButton() {
+  const btn = document.getElementById('cite-btn');
+  if (!btn) return;
+  const { selectedCountry, comparisonCountries } = getState();
+  const disabled = !selectedCountry && comparisonCountries.length === 0;
+  btn.disabled = disabled;
+  btn.title = disabled ? 'Select a country first' : '';
+}
+
 function renderPanel(countryName) {
   const { scoreData, regulationData, comparisonCountries } = getState();
   const score = scoreData[countryName];
@@ -53,11 +75,20 @@ function renderPanel(countryName) {
   document.getElementById('country-name').textContent = countryName;
 
   const badge = document.getElementById('confidence-badge');
-  if (reg && reg.confidence === 'low') {
-    badge.textContent = 'Low confidence';
-    badge.style.display = 'inline-block';
+  const level = normalizeConfidence(reg && reg.confidence);
+  if (level) {
+    badge.textContent = CONFIDENCE_LABELS[level];
+    badge.setAttribute('data-level', level);
+    badge.style.display = 'inline-flex';
+    badge.title = level === 'low'
+      ? 'Sparse public information; treat as indicative.'
+      : level === 'medium'
+      ? 'Based on a mix of primary and secondary sources.'
+      : 'Supported by enacted legislation and recent primary sources.';
   } else {
     badge.style.display = 'none';
+    badge.removeAttribute('data-level');
+    badge.removeAttribute('title');
   }
 
   const dateStr = (score && score.lastUpdated) || (reg && reg.lastUpdated);
@@ -69,6 +100,7 @@ function renderPanel(countryName) {
   renderTextSections(reg);
   highlightCountry(countryName);
   updateCompareButton();
+  updateCiteButton();
 }
 
 function clearPanel() {
@@ -76,6 +108,7 @@ function clearPanel() {
   document.getElementById('panel-content').style.display = 'none';
   clearHighlight();
   updateCompareButton();
+  updateCiteButton();
 }
 
 export function initPanel() {
@@ -96,5 +129,6 @@ export function initPanel() {
   });
 
   on('currentAttribute', updateDimensionHighlight);
-  on('comparisonCountries', updateCompareButton);
+  on('comparisonCountries', () => { updateCompareButton(); updateCiteButton(); });
+  updateCiteButton();
 }

--- a/src/panel/resilience.js
+++ b/src/panel/resilience.js
@@ -1,0 +1,82 @@
+// Resilience helpers — skeleton removal and data-load error boundary.
+//
+// Kept deliberately tiny: just DOM plumbing for the two paths `main()`
+// needs. The copy is honest about the failure but offers the user a
+// way forward (retry + a link to the raw data on GitHub).
+
+export function removeMapSkeleton() {
+  const skel = document.getElementById('map-skeleton');
+  if (skel) skel.remove();
+}
+
+function removeAllChildren(node) {
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+export function showLoadError(err) {
+  // Keep the page shell alive (header, theme toggle, footer, search).
+  // Only the map area is replaced.
+  removeMapSkeleton();
+
+  const map = document.getElementById('map');
+  if (!map) return;
+
+  // Clear any in-flight SVG the renderer may have mounted before the
+  // error was thrown downstream.
+  removeAllChildren(map);
+
+  const wrap = document.createElement('div');
+  wrap.className = 'map-error';
+  wrap.setAttribute('role', 'alert');
+
+  const h = document.createElement('p');
+  h.className = 'map-error-heading';
+  h.textContent = "Couldn't load the regulation data.";
+
+  const detail = document.createElement('p');
+  detail.className = 'map-error-detail';
+  const kind = classifyError(err);
+  detail.textContent = kind === 'network'
+    ? 'A network request failed. Check your connection and try again. The latest snapshot is also available in the GitHub mirror.'
+    : 'The data file returned an unexpected shape. You can inspect the raw CSVs on GitHub.';
+
+  const actions = document.createElement('div');
+  actions.className = 'map-error-actions';
+
+  const retry = document.createElement('button');
+  retry.type = 'button';
+  retry.className = 'map-error-btn';
+  retry.textContent = 'Retry';
+  retry.addEventListener('click', () => window.location.reload());
+
+  const github = document.createElement('a');
+  github.href = 'https://github.com/riadeane/airegulationmap/tree/main/public';
+  github.target = '_blank';
+  github.rel = 'noopener noreferrer';
+  github.className = 'map-error-btn secondary';
+  github.textContent = 'View data on GitHub';
+
+  actions.appendChild(retry);
+  actions.appendChild(github);
+
+  wrap.appendChild(h);
+  wrap.appendChild(detail);
+  wrap.appendChild(actions);
+
+  map.appendChild(wrap);
+
+  // Hide the zoom controls — they'd point at nothing.
+  const zoom = document.getElementById('zoom-controls');
+  if (zoom) zoom.style.display = 'none';
+
+  // Surface the error to anyone tailing the console with a timestamp
+  // so GitHub-issue reports are easier to correlate.
+  console.error('[airegulationmap] data load failed at', new Date().toISOString(), err);
+}
+
+function classifyError(err) {
+  if (!err) return 'unknown';
+  if (err instanceof TypeError) return 'network'; // fetch throws TypeError on network failure
+  if (err.message && /fetch|network|failed to load/i.test(err.message)) return 'network';
+  return 'unknown';
+}

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -7,6 +7,10 @@ const state = {
   selectedCountry: null,
   sortedCountryNames: [],
   comparisonCountries: [],
+  // null = "latest" (use current scoreData as-is); otherwise an ISO date
+  // string (YYYY-MM-DD) present in history.json. The timeline slider
+  // writes this; the map subscribes and re-renders historic scores.
+  timelineDate: null,
 };
 
 const listeners = new Map();

--- a/src/styles/_animations.css
+++ b/src/styles/_animations.css
@@ -17,3 +17,11 @@
   from { opacity: 0; transform: scale(0.97); }
   to { opacity: 1; transform: scale(1); }
 }
+
+/* Slow left-to-right shimmer for the map loading skeleton. The
+   reduced-motion override in _reset.css neutralizes this to a static
+   muted rectangle. */
+@keyframes skeletonShimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}

--- a/src/styles/_header.css
+++ b/src/styles/_header.css
@@ -39,6 +39,35 @@ h1 {
   text-transform: uppercase;
 }
 
+/* "?" info icon next to the site title — links to methodology.html.
+   Sized to match the surrounding header rhythm without reading as a
+   button. */
+.header-methodology-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  color: var(--text-tertiary);
+  font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+  font-size: 0.66rem;
+  font-weight: 500;
+  line-height: 1;
+  text-decoration: none;
+  transition: color 0.15s var(--ease-out), border-color 0.15s var(--ease-out), background 0.15s var(--ease-out);
+  align-self: center;
+  flex-shrink: 0;
+}
+
+.header-methodology-link:hover,
+.header-methodology-link:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-muted);
+}
+
 .country-count-badge {
   font-size: 0.65rem;
   color: var(--accent);

--- a/src/styles/_map.css
+++ b/src/styles/_map.css
@@ -128,3 +128,119 @@
 .graticule {
   pointer-events: none;
 }
+
+/* Map skeleton — shown before TopoJSON + CSV resolve. Muted rectangle
+   with a slow shimmer pass to signal activity without pretending to
+   be a map. Sized to fill the same area the SVG will occupy. */
+#map-skeleton {
+  position: absolute;
+  inset: 0;
+  background: var(--surface);
+  border-radius: 20px;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 24px;
+  animation: fadeIn 0.2s var(--ease-out);
+}
+
+.map-skeleton-shimmer {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--accent-muted) 50%,
+    transparent 100%
+  );
+  opacity: 0.5;
+  animation: skeletonShimmer 2s linear infinite;
+  will-change: transform;
+}
+
+.map-skeleton-label {
+  position: relative;
+  color: var(--text-tertiary);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+}
+
+/* Data-load error state — replaces the map area with an actionable
+   message when CSV / TopoJSON fetches fail. */
+.map-error {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 48px 32px;
+  text-align: center;
+  background: var(--surface);
+  border-radius: 20px;
+}
+
+.map-error-heading {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  margin: 0;
+  max-width: 40ch;
+}
+
+.map-error-detail {
+  color: var(--text-tertiary);
+  font-size: 0.78rem;
+  max-width: 44ch;
+  line-height: 1.55;
+}
+
+.map-error-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.map-error-btn {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--accent);
+  color: var(--bg);
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 8px 16px;
+  font-family: 'Geist', -apple-system, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 0.18s var(--ease-out);
+}
+
+.map-error-btn:hover {
+  background: var(--accent-hover, var(--accent));
+  filter: brightness(1.05);
+}
+
+.map-error-btn.secondary {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+/* sr-only — screen reader only. Reuses the standard recipe. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/styles/_panel.css
+++ b/src/styles/_panel.css
@@ -217,11 +217,13 @@
   background: var(--accent);
 }
 
-/* Confidence badge */
+/* Confidence badge — always visible at high/medium/low, but visual
+   weight scales with how much the reader should worry. High is a
+   quiet tertiary-tone dot (nothing to see); low is the loudest. */
 .confidence-badge {
-  display: none;
-  background: var(--accent-muted);
-  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   font-size: 0.58rem;
   font-weight: 600;
   padding: 3px 8px;
@@ -229,7 +231,160 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   white-space: nowrap;
-  border: 1px solid color-mix(in oklch, var(--accent) 20%, transparent);
+  background: transparent;
+  color: var(--text-tertiary);
+  border: 1px solid transparent;
+}
+
+.confidence-badge::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.confidence-badge[data-level='high'] {
+  /* Understated — "nothing to see" for high-confidence records. */
+  opacity: 0.65;
+}
+
+.confidence-badge[data-level='medium'] {
+  color: oklch(72% 0.15 70); /* amber — tinted toward warning */
+  background: oklch(72% 0.15 70 / 0.10);
+  border-color: oklch(72% 0.15 70 / 0.25);
+}
+
+.confidence-badge[data-level='low'] {
+  color: var(--accent);
+  background: var(--accent-muted);
+  border-color: color-mix(in oklch, var(--accent) 30%, transparent);
+}
+
+/* Panel header actions row — Compare + Cite sit side by side. */
+.panel-header-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+
+.panel-header-actions .compare-btn,
+.panel-header-actions .cite-btn {
+  margin: 0;
+}
+
+.cite-btn {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-family: 'Geist', -apple-system, sans-serif;
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: color 0.15s var(--ease-out), border-color 0.15s var(--ease-out), background 0.15s var(--ease-out);
+}
+
+.cite-btn:hover,
+.cite-btn:focus-visible,
+.cite-btn[aria-expanded='true'] {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-muted);
+}
+
+.cite-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  color: var(--text-tertiary);
+}
+
+/* Cite popover — dropped inline below the header actions. Not a
+   modal; just a contextual box that dismisses on outside click. */
+.cite-popover {
+  margin-top: 12px;
+  padding: 14px 16px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  animation: fadeUp 0.22s var(--ease-out);
+}
+
+.cite-popover[hidden] { display: none; }
+
+.cite-popover-heading {
+  font-size: 0.66rem;
+  color: var(--text-tertiary);
+  margin-bottom: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.cite-row { margin-bottom: 12px; }
+.cite-row:last-child { margin-bottom: 0; }
+
+.cite-row-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.cite-format {
+  font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  color: var(--text-primary);
+  text-transform: uppercase;
+}
+
+.cite-copy {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-family: 'Geist', -apple-system, sans-serif;
+  font-size: 0.66rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: color 0.15s var(--ease-out), border-color 0.15s var(--ease-out), background 0.15s var(--ease-out);
+}
+
+.cite-copy:hover,
+.cite-copy:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-muted);
+}
+
+.cite-copy.copied {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-muted);
+}
+
+.cite-block {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 /* Sources */

--- a/src/styles/_reset.css
+++ b/src/styles/_reset.css
@@ -84,3 +84,39 @@ input:focus-visible,
     scroll-behavior: auto !important;
   }
 }
+
+/* No-JS fallback. Keeps the copy quiet and points to the methodology
+   page (which is static HTML) and the public data files on GitHub. */
+.noscript-fallback {
+  max-width: 60ch;
+  margin: 48px auto;
+  padding: 24px 32px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 8px);
+  font-family: 'Geist', -apple-system, sans-serif;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.noscript-fallback h1 {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 14px;
+  letter-spacing: -0.005em;
+}
+
+.noscript-fallback ul {
+  margin-top: 10px;
+  padding-left: 20px;
+}
+
+.noscript-fallback li { margin-bottom: 6px; }
+
+.noscript-fallback a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}


### PR DESCRIPTION
## Summary
- **Shareable URLs** — `?country=`, `?mode=`, `?compare=`, `?date=`, `?theme=` encode every meaningful view; state → URL via `replaceState`, URL → state via `popstate`. Theme resolved pre-paint (URL > localStorage > prefers-color-scheme) so no FOUC.
- **Methodology page + Cite action** — new static `public/methodology.html` (printable, no-JS, indexable) with the 1–5 rubric per dimension and the epistemic caveat. "Cite" button on the country panel opens a popover with APA / Chicago / MLA strings embedding the live permalink, one-tap copy with Clipboard API + `execCommand` fallback.
- **Resilience** — map skeleton shimmer while CSV/TopoJSON load, `try/catch` error boundary with Retry + GitHub mirror link, `<noscript>` fallback, `role="img"` + `<title>` + `aria-label` on the SVG, polite sr-only live region announces the current mode on `currentAttribute` change.

Plan: `docs/plans/2026-04-17-citability-and-resilience.md`.

## Design notes
- Confidence badge now always visible (high/medium/low dot + label), not only on low-confidence rows.
- Timeline routed through the store via a new `timelineDate` state key so URL sync composes with it and the map re-renders historic scores via the standard subscription path.
- No new runtime dependencies. Vanilla JS, tokens reused.

## Test plan
- [ ] `/?country=Germany` opens the Germany panel; `/?compare=Germany,France,Japan&mode=enforcementLevel` opens the comparison with the right mode.
- [ ] Click/navigate around — URL updates live. Back/forward buttons restore state.
- [ ] `/?theme=light` and `/?theme=dark` apply pre-paint (no FOUC); toggle button reflects.
- [ ] On a country panel, click **Cite** → popover shows three formats → each **Copy** button fills the clipboard and flashes "Copied ✓".
- [ ] Navigate to `/methodology.html` → page renders with the main app's typography, no JS required, print preview looks clean. Site title links back to `/`.
- [ ] Disable JavaScript → `<noscript>` fallback renders with working methodology + GitHub links.
- [ ] Throttle to Slow 3G → skeleton visible before map mounts. Block the `scores.csv` fetch → error state renders with a Retry button.
- [ ] Screen reader: focus the SVG → announces "World map showing AI regulation scores…". Change score dimension → live region announces the new mode and legend endpoints.
- [ ] `npm run build` succeeds; `dist/methodology.html` is emitted alongside `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)