### PR TITLE
Polish pass, mobile tactical fix, and mobile/architecture proposal

### DIFF
--- a/docs/plans/2026-04-17-polish-and-onramp-spec.md
+++ b/docs/plans/2026-04-17-polish-and-onramp-spec.md
@@ -1,0 +1,319 @@
+# Polish & On-ramp — Design Spec
+
+> Sibling to `docs/plans/2026-04-17-citability-and-resilience.md` (already shipped). Does not duplicate.
+
+**Date:** 2026-04-17
+**Status:** Design approved, pending plan generation
+
+## Goal
+
+A weekend-scoped polish pass addressing four gaps in the current app:
+
+1. Copy quality on LLM-generated country descriptions — display-layer fix
+2. Narrative scaffolding / first-visit on-ramp — compressed form, not a full landing page
+3. Freshness and authority signals — surface existing data, don't add new data
+4. `?` keyboard shortcut help overlay — expose shortcuts already wired
+
+## Out of scope
+
+- Source-side copy fix (editing `scripts/regulation_pipeline/api.py`, re-running the pipeline, reviewing 196 outputs). Separate plan, later. Design reference: path (A) in brainstorm.
+- Full narrative scaffolding (scroll-driven homepage, editorial numbered sections à la trackpolicy.org). Acknowledged as highest-leverage future move; methodology page already covers the reference-document side.
+- Operational-freshness affordances: recent-activity feed, "what changed this month" ticker, temporal-activity spine. These dilute the differentiator (durable structured comparison across 196 countries).
+- New fonts, palette, animations. Framework migration.
+- Per-field confidence. Still record-level, per the citability plan's deferred note.
+
+## Design principles (carried from `.impeccable.md`)
+
+1. **The map is the protagonist.** New UI recedes or only appears when no country is selected.
+2. **Rigor over ornament.** Every change surfaces existing information, not decoration.
+3. **Citeable by default.** Freshness signals are honest, including "no sources" states.
+4. **Calm density.** The on-ramp uses typographic hierarchy, not color or iconography.
+
+## Architecture
+
+Vanilla JS + D3 + Vite, no new dependencies. State store (`src/state/store.js`) unchanged. URL-sync behavior unchanged. No data file changes.
+
+### Files
+
+| Feature | New | Modified |
+|---|---|---|
+| Copy normalizer | `src/panel/normalize.js` | `src/panel/sections.js`, `src/constants.js` |
+| Empty-panel on-ramp | — | `index.html`, `src/styles/_panel.css`, `src/panel/index.js` |
+| Freshness signals | — | `src/panel/index.js` |
+| Help overlay | `src/controls/helpOverlay.js`, `src/styles/_overlay.css` | `index.html`, `src/controls/search.js`, `src/styles/main.css`, `src/styles/_reset.css` (shared `<kbd>` base) |
+
+---
+
+## 1. Copy normalizer
+
+**Problem:** LLM-generated descriptions in `public/regulation_data.csv` have repetitive patterns — "as of April 2026" leads, cascading "No X / No Y / No Z exists" constructions, standalone hedges. Reads stiff.
+
+**Approach:** a small normalizer at display time. CSV data is untouched.
+
+### Module — `src/panel/normalize.js`
+
+Export a single function:
+
+```js
+export function normalizeRegulationText(text) → string | null
+```
+
+Applied inside `cleanRegulationText` in `src/panel/sections.js`, after existing placeholder and short-hedge checks, before returning to the render path.
+
+### Transformations
+
+Three conservative passes, applied in order:
+
+1. **Strip leading temporal anchor.** If the substring `as of (January|February|...|December) \d{4}` appears within the first 80 chars AND at least one more sentence of content follows, remove it and the surrounding spaces/commas. Preserves trailing "as of …" which often carries genuine temporal framing mid-paragraph.
+2. **Collapse cascading negations.** When three or more consecutive sentences each open with `No ` (case-sensitive, capital N after sentence boundary), AND their remaining tokens overlap by ≥2 non-stopword tokens (heuristic: shared vocabulary signals redundant claims), collapse to a single sentence: `"No AI-specific legislation, governance body, or enforcement mechanism exists."` — joining the subject nouns from each original sentence. When tails diverge (distinct claims), skip.
+3. **Trim leading hedges.** Strip standalone `Generally,`, `Broadly,`, `Notably,` at sentence start.
+
+### Safety rail
+
+If `output.length < input.length * 0.6` OR `output.trim() === ''`, return the original input unchanged. Guards against regex catastrophe on unusual text shapes.
+
+### Feature flag
+
+In `src/constants.js`:
+
+```js
+export const NORMALIZE_COPY = true;
+```
+
+`normalizeRegulationText` early-returns when flag is false. Allows A/B inspection without a rebuild.
+
+### Verification
+
+Eyeball 10 countries across confidence tiers in the dev server:
+
+- Afghanistan, Algeria, Angola, Antigua and Barbuda (heavy "No X" cascades)
+- Argentina, Germany, France (substantive content, check for over-normalization)
+- Singapore, Kenya, Bolivia (mid-register)
+- Belarus (edge case: potentially unusual structure)
+
+For each: confirm text is shorter or equal, reads cleaner, retains factual content. No unit tests — eyeball is faster for a weekend's worth of regex.
+
+---
+
+## 2. Empty-panel on-ramp
+
+**Problem:** First-time visitors land on the map with no orientation. The current `#no-selection-message` is one line: "Select a country to see details." Plus a tip about Shift-click. Neither teaches what the site is.
+
+**Approach:** a compressed narrative block in the country panel that only appears on first load. Borrows the numbered-section device from trackpolicy.org at small scale, without requiring a scroll-driven layout. Removed permanently on first engagement.
+
+### Markup — `index.html`
+
+The current markup is a single `<p id="no-selection-message">` inside `#country-panel` before `#panel-content`. Remove it and add two siblings in its place — the rich intro (visible) and a hidden simple one-liner for the deselected-after-engagement case:
+
+```html
+<div id="panel-intro" class="panel-intro">
+  <p class="panel-intro-lede">Global AI governance across 196 countries, scored on six dimensions.</p>
+  <ol class="panel-intro-steps">
+    <li><span class="panel-intro-num">01</span> Click a country to read its regulatory posture.</li>
+    <li><span class="panel-intro-num">02</span> Shift-click to compare up to four.</li>
+    <li><span class="panel-intro-num">03</span> Press <kbd>?</kbd> for keyboard shortcuts.</li>
+  </ol>
+  <a class="panel-intro-methodology" href="/methodology.html">Read the methodology →</a>
+</div>
+<p id="no-selection-message" class="no-selection-message" hidden>Select a country to see details.</p>
+```
+
+Both elements sit in the same parent (`#country-panel`), one visible and one hidden at initial render. The state transition below swaps them.
+
+### Styles — `src/styles/_panel.css`
+
+| Selector | Properties |
+|---|---|
+| `.panel-intro` | Padding matches existing `#no-selection-message`, max-width for readability |
+| `.panel-intro-lede` | Literata, ~1.15–1.2rem, line-height ~1.35, `--text-primary`, margin-bottom 1.5em |
+| `.panel-intro-steps` | No default list markers; vertical gap between items |
+| `.panel-intro-num` | Geist Mono, `--text-tertiary`, tabular-nums, fixed-width gutter |
+| `.panel-intro-steps li` | Sans, `--text-secondary`, line-height 1.5 |
+| `.panel-intro-methodology` | Quiet link, `--accent` on hover, small arrow |
+
+### State transition — `src/panel/index.js`
+
+Add a subscription (or extend an existing one) that runs once:
+
+```js
+let introConsumed = false;
+function maybeConsumeIntro() {
+  if (introConsumed) return;
+  const { selectedCountry, comparisonCountries } = getState();
+  if (selectedCountry || (comparisonCountries && comparisonCountries.length > 0)) {
+    introConsumed = true;
+    const intro = document.getElementById('panel-intro');
+    if (intro) intro.remove();
+    const fallback = document.getElementById('no-selection-message');
+    if (fallback) fallback.hidden = false;
+  }
+}
+on('selectedCountry', maybeConsumeIntro);
+on('comparisonCountries', maybeConsumeIntro);
+```
+
+After first engagement, subsequent deselect shows the plain one-liner. The intro is once-per-page-load. No localStorage — users who reload get the intro back, which is fine.
+
+---
+
+## 3. Freshness / authority signals
+
+**What already ships:** always-visible three-tier confidence badge (see `src/panel/index.js:77-92` and `src/styles/_panel.css:220-263`). High reads quiet at opacity 0.65, medium amber, low loud-accent. The Task 2.5 compromise from the citability plan did land.
+
+**What's still missing:** source count inline with the date. A researcher currently sees `"Data as of 2026-04-01"` with no signal for how many primary sources back the entry. Surfacing the count is honest about the data's provenance.
+
+**Approach:** extend the existing `#last-updated` render in `src/panel/index.js`. The `regulationData[country].sources` field is pipe-separated URLs; count them, append to the date line.
+
+Behavior:
+
+```js
+// Inside renderPanel, after computing dateStr:
+const urls = reg?.sources
+  ? reg.sources.split('|').map(u => u.trim()).filter(Boolean)
+  : [];
+const countText = urls.length > 0
+  ? `${urls.length} source${urls.length === 1 ? '' : 's'}`
+  : 'no primary sources';
+const dateLine = dateStr ? `Data as of ${dateStr} · ${countText}` : countText;
+document.getElementById('last-updated').textContent = dateLine;
+```
+
+When zero sources, the line reads "no primary sources" — honest rather than hidden. The existing `renderTextSections` render in `src/panel/sections.js` parses the same URL list for chip rendering; a minor shared-parse refactor is optional but not required for correctness (they're cheap to compute twice).
+
+No CSS changes required — `.data-freshness` already renders the line in the right style. Nothing else is added here; the three-tier confidence treatment stays as-is.
+
+---
+
+## 4. Help overlay
+
+**Problem:** Keyboard shortcuts (`/`, `⌘K`, arrows, `Esc`, Shift-click) are wired but undiscoverable. No reference for first-time users.
+
+**Approach:** a native `<dialog>` overlay listing every shortcut, opened by the `?` key or the header `?` icon.
+
+### Module — `src/controls/helpOverlay.js`
+
+```js
+export function initHelpOverlay() {
+  const dialog = document.getElementById('help-overlay');
+  if (!dialog) return;
+  document.getElementById('help-overlay-close')
+    ?.addEventListener('click', () => dialog.close());
+  document.getElementById('header-help-btn')
+    ?.addEventListener('click', () => dialog.showModal());
+  dialog.addEventListener('click', (e) => {
+    if (e.target === dialog) dialog.close(); // backdrop click
+  });
+}
+export function openHelpOverlay() {
+  const d = document.getElementById('help-overlay');
+  if (d && !d.open) d.showModal();
+}
+```
+
+Called from `src/main.js` alongside other `init*` calls.
+
+### Markup — `index.html`
+
+Change the existing header link:
+
+```html
+<button
+  id="header-help-btn"
+  class="header-help-btn"
+  type="button"
+  aria-label="Keyboard shortcuts and help"
+  title="Keyboard shortcuts"
+>?</button>
+```
+
+Add the dialog just before `</body>`:
+
+```html
+<dialog id="help-overlay" class="help-overlay" aria-label="Keyboard shortcuts and help">
+  <div class="help-overlay-inner">
+    <button id="help-overlay-close" class="help-overlay-close" type="button" aria-label="Close">×</button>
+    <h2 class="help-overlay-title">Keyboard shortcuts</h2>
+    <div class="help-overlay-grid">
+      <dl>
+        <dt><kbd>/</kbd> or <kbd>⌘</kbd><kbd>K</kbd></dt><dd>Focus search</dd>
+        <dt><kbd>←</kbd> <kbd>→</kbd></dt><dd>Step through countries</dd>
+        <dt><kbd>?</kbd></dt><dd>This menu</dd>
+      </dl>
+      <dl>
+        <dt>Click</dt><dd>Select country</dd>
+        <dt>Shift+click</dt><dd>Add to comparison</dd>
+        <dt><kbd>Esc</kbd></dt><dd>Close / deselect</dd>
+      </dl>
+    </div>
+    <p class="help-overlay-footer">More detail in the <a href="/methodology.html">methodology</a>.</p>
+  </div>
+</dialog>
+```
+
+### Styles
+
+Base `<kbd>` styles live in `src/styles/_reset.css` so they're shared by both the help overlay and the empty-panel intro (which uses `<kbd>?</kbd>`). Shape: small monospace pill, `--surface-raised` background, `--border-subtle` outline, `--radius-sm`, `font-family: 'Geist Mono'`, ~0.8em, tabular numerics. Works against any theme.
+
+Overlay-specific styles in `src/styles/_overlay.css`, imported from `src/styles/main.css`:
+
+- `.help-overlay` — native dialog reset (remove default border/padding), `--surface` background, `--border`, `--radius` matching other panels, max-width ~480px
+- `.help-overlay::backdrop` — dim overlay (e.g. `rgb(0 0 0 / 0.4)`), respecting theme
+- `.help-overlay-inner` — padding, typography
+- `.help-overlay-grid` — CSS grid, two columns, collapse to one on narrow
+- `.help-overlay-close` — top-right absolute, subtle
+
+### Key binding
+
+In `src/controls/search.js`, inside `initKeyboardNav`, before the ArrowLeft/ArrowRight handler:
+
+```js
+if (e.key === '?') {
+  e.preventDefault();
+  document.getElementById('help-overlay').showModal();
+  return;
+}
+```
+
+Match the existing guard that skips when `e.target` is input/textarea.
+
+### Decision recorded: header `?` behavior
+
+The header `?` icon currently links directly to `/methodology.html`. After this change, it opens the overlay instead. Methodology remains reachable via:
+
+- Footer link
+- Overlay footer ("More detail in the methodology")
+- Empty-panel intro ("Read the methodology →")
+
+Rationale: one affordance for help (overlay), one page for the deep reference (methodology). If this feels like a regression once live, revert this specific line.
+
+### Accessibility
+
+Native `<dialog>` provides focus trap, Esc-to-close, and `::backdrop` for free. Explicit close button for users who don't know Esc. `aria-label` on the dialog. Semantic `<kbd>` elements.
+
+---
+
+## Build sequence
+
+Four independently-revertable commits, in this order:
+
+1. **Copy normalizer.** Most isolated. Can ship even if the others slip.
+2. **Source-count in date line.** A handful of JS lines in `src/panel/index.js`. Zero CSS, zero new markup.
+3. **Empty-panel on-ramp.** Pure markup + CSS + one store subscription.
+4. **Help overlay.** Biggest new surface; last so it doesn't block earlier wins.
+
+Each commit is verifiable in the dev server before moving on.
+
+## Success criteria
+
+- Dev server loaded cold → intro visible in the empty panel → three numbered steps legible → methodology link present.
+- Click any country → intro removed from DOM → never returns for this page load.
+- Afghanistan, Angola, Antigua panels: descriptions no longer open with "as of [Month Year]"; cascading "No X" sentences collapsed to one.
+- Country header's `Data as of <date>` line now includes inline source count (e.g. `· 3 sources`), with honest "no primary sources" fallback when empty. Existing three-tier confidence badge unchanged.
+- Press `?` on any page state (outside inputs) → overlay opens → tab-cycles stay inside → Esc closes → backdrop click closes.
+- No new entries in `package.json`.
+- Lighthouse accessibility score ≥ current baseline on both themes.
+
+## Open decisions (captured from brainstorm)
+
+1. **Numbered vs. unnumbered on-ramp.** Ship numbered first. If it reads imposed ("narrative device from her site pasted onto yours"), strip to three equal-weight short lines. Evaluated after the commit lands.
+2. **Header `?` behavior change.** Now opens overlay instead of linking to methodology. Reverted to direct-to-methodology if the UX feels like a regression.

--- a/docs/plans/2026-04-17-polish-and-onramp.md
+++ b/docs/plans/2026-04-17-polish-and-onramp.md
@@ -1,0 +1,930 @@
+# Polish & On-ramp Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** A weekend-scoped polish pass on `airegulationmap.org` — a display-layer copy normalizer, a compressed first-visit on-ramp in the empty country panel, a source-count signal in the per-country date line, and a `?` keyboard-shortcut help overlay. No new data, no new dependencies, no framework migration.
+
+**Architecture:** Vanilla JS + D3 + Vite, as-is. One new display module (`src/panel/normalize.js`), one new UI module (`src/controls/helpOverlay.js`), one new stylesheet partial (`src/styles/_overlay.css`). All other changes are edits to existing files. URL-sync, state store, and data loaders are untouched.
+
+**Tech Stack:** Vanilla JS, D3.js 7, TopoJSON, Vite, OKLCH tokens.
+
+**Design doc:** [2026-04-17-polish-and-onramp-spec.md](./2026-04-17-polish-and-onramp-spec.md) — read first if unclear on any task's intent.
+
+**Design principles to honor throughout:**
+- Principle 1 (map is protagonist): the on-ramp lives in the empty panel and is removed on first engagement — no global chrome added.
+- Principle 2 (rigor over ornament): no animations, no gradients, no color tokens outside the existing palette.
+- Principle 4 (citeable by default): the source-count line is honest about "no primary sources" rather than hiding the zero case.
+
+**Sibling plans (do not duplicate):**
+- [2026-04-17-citability-and-resilience.md](./2026-04-17-citability-and-resilience.md) — already shipped. Methodology page, permalinks, cite popover, skeleton + error state, noscript fallback, three-tier confidence badge.
+
+---
+
+## Task 1: Copy normalizer
+
+**Goal:** Strip repetitive boilerplate from LLM-generated regulation descriptions at display time. CSV data is untouched. A feature flag lets you disable the transform for A/B inspection.
+
+**Files:**
+- Create: `src/panel/normalize.js`
+- Modify: `src/constants.js` (add `NORMALIZE_COPY` flag)
+- Modify: `src/panel/sections.js` (call normalizer inside `cleanRegulationText`)
+
+### Step 1.1 — Add the feature flag
+
+In `src/constants.js`, append a new export at the bottom:
+
+```js
+// Display-time cleanup of LLM-generated regulation descriptions.
+// Set to false for A/B eyeballing against the raw CSV text.
+export const NORMALIZE_COPY = true;
+```
+
+### Step 1.2 — Create `src/panel/normalize.js`
+
+Full file contents:
+
+```js
+// Display-time text cleanup for LLM-generated regulation descriptions.
+//
+// Three conservative passes, each opt-out on guard. If the normalizer
+// shrinks the text below 60% of its original length or produces an empty
+// string, return the original — better stiff than factually truncated.
+//
+// CSV data is never modified. Every call is scoped to one free-text field
+// at render time in src/panel/sections.js.
+
+import { NORMALIZE_COPY } from '../constants.js';
+
+const MONTHS = 'January|February|March|April|May|June|July|August|September|October|November|December';
+
+// "Country X has no Y, as of April 2026." → strip the "as of …" clause.
+// Only applied when the phrase lives inside the first 80 characters AND
+// at least one further sentence follows. Preserves trailing "as of …"
+// which often carries legitimate anchoring mid-paragraph.
+const LEADING_TEMPORAL_RE = new RegExp(
+  `^([\\s\\S]{0,80}?)\\s*(?:,\\s*)?as of (?:${MONTHS}) \\d{4}\\s*(?=[.,])`,
+  'i'
+);
+
+// Stopwords for the cascading-negation vocabulary-overlap heuristic.
+const STOPWORDS = new Set([
+  'a','an','the','of','on','in','to','for','and','or','but','at','by','with',
+  'is','are','was','were','be','been','being','has','have','had','do','does',
+  'did','will','would','can','could','should','as','that','this','these','those',
+  'it','its','he','she','they','them','their','there','here','than','then','so',
+  'no','not','any','all','some','such','only','also','yet','from','into','over',
+  'under','about','through','between','among','per','via','nor','exist','exists'
+]);
+
+function tokens(s) {
+  return (s.toLowerCase().match(/[a-z][a-z-]+/g) || [])
+    .filter(t => !STOPWORDS.has(t) && t.length > 2);
+}
+
+function stripLeadingTemporal(text) {
+  const sentenceCount = (text.match(/[.!?](\s|$)/g) || []).length;
+  if (sentenceCount < 2) return text;
+  return text.replace(LEADING_TEMPORAL_RE, '$1').replace(/^\s*,\s*/, '').trim();
+}
+
+// Heuristic: a run of sentences all starting with "No " is redundant if
+// every sentence after the first shares ≥2 non-stopword tokens with the
+// first. Conservative — genuinely distinct claims fall through.
+function sharesVocab(sentences) {
+  const firstTokens = new Set(tokens(sentences[0]));
+  if (firstTokens.size < 2) return false;
+  for (let i = 1; i < sentences.length; i++) {
+    const shared = tokens(sentences[i]).filter(w => firstTokens.has(w)).length;
+    if (shared < 2) return false;
+  }
+  return true;
+}
+
+function collapseCascadingNegations(text) {
+  const sentences = text.match(/[^.!?]+[.!?]+\s*/g);
+  if (!sentences || sentences.length < 3) return text;
+
+  const out = [];
+  let run = [];
+
+  const flushRun = () => {
+    if (run.length >= 3 && sharesVocab(run)) {
+      out.push('No AI-specific legislation, governance body, or enforcement mechanism exists. ');
+    } else {
+      out.push(...run);
+    }
+    run = [];
+  };
+
+  for (const s of sentences) {
+    if (/^\s*No\s/.test(s)) {
+      run.push(s);
+    } else {
+      flushRun();
+      out.push(s);
+    }
+  }
+  flushRun();
+  return out.join('').trim();
+}
+
+function trimLeadingHedges(text) {
+  return text
+    .replace(/^(Generally|Broadly|Notably|Essentially|Largely),\s*/i, '')
+    .replace(/([.!?]\s+)(Generally|Broadly|Notably|Essentially|Largely),\s+/g, '$1');
+}
+
+export function normalizeRegulationText(text) {
+  if (!NORMALIZE_COPY) return text;
+  if (!text || typeof text !== 'string') return text;
+
+  const original = text;
+  let out = text;
+
+  out = stripLeadingTemporal(out);
+  out = collapseCascadingNegations(out);
+  out = trimLeadingHedges(out);
+
+  // Safety rail — never silently chew a claim into nothing.
+  if (!out || out.trim().length === 0) return original;
+  if (out.length < original.length * 0.6) return original;
+  return out;
+}
+```
+
+### Step 1.3 — Wire into `cleanRegulationText`
+
+In `src/panel/sections.js`, update the imports and the `cleanRegulationText` function:
+
+```js
+import { PLACEHOLDER_RE } from '../constants.js';
+import { normalizeRegulationText } from './normalize.js';
+
+export function showSection(id, show) {
+  const el = document.getElementById(id);
+  if (el) el.style.display = show ? '' : 'none';
+}
+
+export function cleanRegulationText(text) {
+  if (!text || typeof text !== 'string') return null;
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return null;
+  if (PLACEHOLDER_RE.test(trimmed)) return null;
+  if (/^(cf\.|Cf\.)\s/i.test(trimmed) && trimmed.length < 40) return null;
+  if (/^idem\b/i.test(trimmed) && trimmed.length < 10) return null;
+  return normalizeRegulationText(trimmed);
+}
+```
+
+Only the last two lines change — the import and the `return` of `cleanRegulationText`. Leave the rest of the file intact.
+
+### Step 1.4 — Verify in the dev server
+
+Run:
+
+```bash
+npm run dev
+```
+
+Open the local URL, then click through these 10 countries in the panel. For each, confirm the text reads cleaner (shorter, no "as of April 2026" stock openers, no cascading "No X" chains) without losing factual content:
+
+- Afghanistan (heavy "No X" cascade)
+- Algeria (moderate cascade, temporal opener)
+- Angola (cascade)
+- Antigua and Barbuda (cascade)
+- Argentina (substantive content — should be mostly unchanged)
+- Germany (rich content — should be mostly unchanged)
+- France (rich content — should be mostly unchanged)
+- Singapore (mid-register)
+- Kenya (mid-register)
+- Belarus (edge case — unusual structure)
+
+Then flip the flag to confirm the opt-out works:
+
+1. In `src/constants.js`, change `export const NORMALIZE_COPY = true;` to `false;`.
+2. Save — Vite HMR refreshes.
+3. Open Afghanistan again — text should now show the original "as of March 2026" opener and all cascading "No X" sentences.
+4. Flip back to `true`.
+
+### Step 1.5 — Commit
+
+```bash
+git add src/panel/normalize.js src/panel/sections.js src/constants.js
+git commit -m "feat: normalize LLM-generated country descriptions at display time"
+```
+
+---
+
+## Task 2: Source-count in date line
+
+**Goal:** Surface a count of primary sources inline with the "Data as of YYYY-MM-DD" line in the country header. Honest "no primary sources" fallback when empty.
+
+**Files:**
+- Modify: `src/panel/index.js`
+
+### Step 2.1 — Extend `renderPanel`
+
+In `src/panel/index.js`, find the `dateStr` block (currently around lines 94–95):
+
+```js
+const dateStr = (score && score.lastUpdated) || (reg && reg.lastUpdated);
+document.getElementById('last-updated').textContent = dateStr ? `Data as of ${dateStr}` : '';
+```
+
+Replace with:
+
+```js
+const dateStr = (score && score.lastUpdated) || (reg && reg.lastUpdated);
+const sourceUrls = reg && reg.sources
+  ? reg.sources.split('|').map(u => u.trim()).filter(Boolean)
+  : [];
+const countText = sourceUrls.length > 0
+  ? `${sourceUrls.length} source${sourceUrls.length === 1 ? '' : 's'}`
+  : 'no primary sources';
+document.getElementById('last-updated').textContent = dateStr
+  ? `Data as of ${dateStr} · ${countText}`
+  : countText;
+```
+
+Nothing else in the file changes.
+
+### Step 2.2 — Verify
+
+With the dev server still running from Task 1:
+
+1. Click Germany (or any country with multiple sources) → date line reads like `Data as of 2026-03-21 · 3 sources`.
+2. Click Afghanistan (no sources in the CSV as of April 2026) → date line reads `Data as of 2026-03-21 · no primary sources`.
+3. Click a country with exactly one source → `· 1 source` (singular).
+
+Spot-check on both light and dark themes by toggling the theme button in the header.
+
+### Step 2.3 — Commit
+
+```bash
+git add src/panel/index.js
+git commit -m "feat: surface source count inline with per-country date line"
+```
+
+---
+
+## Task 3: Empty-panel on-ramp
+
+**Goal:** Replace the single-line empty-panel message with a richer orientation moment — a display-weight lede, three numbered steps, a methodology link. Removed from the DOM on first engagement; a plain one-liner takes its place for subsequent deselects.
+
+**Files:**
+- Modify: `src/styles/_reset.css` (add shared `<kbd>` base styles)
+- Modify: `index.html` (replace `#no-selection-message` markup)
+- Modify: `src/styles/_panel.css` (add `.panel-intro` styles)
+- Modify: `src/panel/index.js` (state transition: remove intro on first engage; show plain one-liner thereafter)
+
+### Step 3.1 — Add shared `<kbd>` base styles
+
+The `<kbd>` element is used both by the overlay (Task 4) and by the empty-panel intro below. Keep the base styling in `_reset.css` so both consumers share one source.
+
+In `src/styles/_reset.css`, append at the bottom (after the `.noscript-fallback` rules):
+
+```css
+/* Keyboard-key pill. Shared by the empty-panel on-ramp and the help
+   overlay. Small monospace badge; inherits color from the surrounding
+   text so it reads quiet. */
+kbd {
+  display: inline-block;
+  min-width: 1.4em;
+  padding: 0 0.4em;
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.82em;
+  font-weight: 500;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  vertical-align: baseline;
+}
+```
+
+### Step 3.2 — Replace the empty-panel markup
+
+In `index.html`, find the current empty-panel paragraph (inside `<aside id="country-panel">`, currently around line 155):
+
+```html
+<p id="no-selection-message">Select a country to see details.<br><span class="hint">Tip: Shift+click two or more countries to compare them.</span></p>
+```
+
+Replace with:
+
+```html
+<div id="panel-intro" class="panel-intro">
+  <p class="panel-intro-lede">Global AI governance across 196 countries, scored on six dimensions.</p>
+  <ol class="panel-intro-steps">
+    <li><span class="panel-intro-num">01</span> Click a country to read its regulatory posture.</li>
+    <li><span class="panel-intro-num">02</span> Shift-click to compare up to four.</li>
+    <li><span class="panel-intro-num">03</span> Press <kbd>?</kbd> for keyboard shortcuts.</li>
+  </ol>
+  <a class="panel-intro-methodology" href="/methodology.html">Read the methodology &rarr;</a>
+</div>
+<p id="no-selection-message" class="no-selection-message" hidden>Select a country to see details.</p>
+```
+
+Two elements sit where there used to be one. The intro is visible at initial render; `#no-selection-message` starts hidden.
+
+### Step 3.3 — Add `.panel-intro` styles
+
+In `src/styles/_panel.css`, append at the bottom of the file:
+
+```css
+/* ── Empty-panel on-ramp ──────────────────────────────────────
+   Shown once, on first load, before any country is selected.
+   Removed from the DOM on first engagement (see src/panel/index.js).
+   After that, #no-selection-message takes over as a quiet one-liner.
+   ----------------------------------------------------------- */
+.panel-intro {
+  padding: 28px 22px 24px;
+  max-width: 320px;
+}
+
+.panel-intro-lede {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 1.15rem;
+  font-weight: 400;
+  line-height: 1.35;
+  color: var(--text-primary);
+  letter-spacing: -0.005em;
+  margin-bottom: 22px;
+}
+
+.panel-intro-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel-intro-steps li {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.panel-intro-num {
+  font-family: 'Geist Mono', ui-monospace, monospace;
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+  min-width: 1.8em;
+}
+
+.panel-intro-methodology {
+  display: inline-block;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 1px;
+  transition: color 0.15s var(--ease-out), border-color 0.15s var(--ease-out);
+}
+
+.panel-intro-methodology:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.no-selection-message {
+  padding: 24px 22px;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+```
+
+The rule for `.no-selection-message` replaces any existing styling for `#no-selection-message`. If the existing file has an older `#no-selection-message` rule, leave it — the `hidden` attribute on the element is an HTML-level override that wins regardless. (Claude can remove it as cleanup if obvious; otherwise leave it.)
+
+### Step 3.4 — State transition in `src/panel/index.js`
+
+Two changes:
+1. Add a once-per-session subscription that removes `#panel-intro` from the DOM on first `selectedCountry` or `comparisonCountries` engagement.
+2. Update `clearPanel` to show `#no-selection-message` (the plain one-liner) after engagement, not the intro.
+
+Open `src/panel/index.js`. Find `clearPanel` (currently around line 106):
+
+```js
+function clearPanel() {
+  document.getElementById('no-selection-message').style.display = '';
+  document.getElementById('panel-content').style.display = 'none';
+  clearHighlight();
+  updateCompareButton();
+  updateCiteButton();
+}
+```
+
+Replace with:
+
+```js
+function clearPanel() {
+  const fallback = document.getElementById('no-selection-message');
+  if (fallback) fallback.hidden = false;
+  document.getElementById('panel-content').style.display = 'none';
+  clearHighlight();
+  updateCompareButton();
+  updateCiteButton();
+}
+```
+
+Note the swap from `style.display = ''` to the `hidden` attribute — matches the markup change in Step 3.2.
+
+Next, find `renderPanel` (around line 61). Inside the `if (!comparisonActive)` block near the top (around line 70):
+
+```js
+if (!comparisonActive) {
+  document.getElementById('no-selection-message').style.display = 'none';
+  document.getElementById('panel-content').style.display = '';
+}
+```
+
+Replace with:
+
+```js
+if (!comparisonActive) {
+  const fallback = document.getElementById('no-selection-message');
+  if (fallback) fallback.hidden = true;
+  document.getElementById('panel-content').style.display = '';
+}
+```
+
+Finally, add the intro-removal logic. At the end of `initPanel` (currently ends around line 134), just before the closing `}`, add:
+
+```js
+  let introConsumed = false;
+  const consumeIntro = () => {
+    if (introConsumed) return;
+    const { selectedCountry, comparisonCountries } = getState();
+    if (selectedCountry || (comparisonCountries && comparisonCountries.length > 0)) {
+      introConsumed = true;
+      const intro = document.getElementById('panel-intro');
+      if (intro) intro.remove();
+    }
+  };
+  on('selectedCountry', consumeIntro);
+  on('comparisonCountries', consumeIntro);
+```
+
+`consumeIntro` runs on every state change but early-returns after the first engagement. The DOM node is physically removed so it can't come back. The `#no-selection-message` one-liner takes its place on subsequent deselects.
+
+### Step 3.5 — Verify
+
+With the dev server still running:
+
+1. Hard-reload the page (Cmd+Shift+R) with no country selected in the URL. Expected: the panel shows the Literata lede, three numbered steps (01 / 02 / 03), and the methodology link. Take a screenshot if you want to compare later.
+2. Click any country → country panel renders; reload the page; the intro comes back (once per page load is correct).
+3. Click a country → panel renders → press Esc → now shows "Select a country to see details." in the quiet italic style. Confirm the intro does NOT return.
+4. Click a country again → panel renders. Reload → intro returns.
+5. Toggle light/dark theme → the lede Literata color, the Geist Mono numbers, and the methodology link border all read correctly on both.
+6. Press Tab from the search input → the methodology link inside the intro should receive focus with the global `:focus-visible` ring.
+
+### Step 3.6 — Commit
+
+```bash
+git add src/styles/_reset.css src/styles/_panel.css index.html src/panel/index.js
+git commit -m "feat: orientation on-ramp in empty country panel"
+```
+
+---
+
+## Task 4: Help overlay
+
+**Goal:** A native `<dialog>` surfaces every keyboard shortcut the app already wires. Opens via `?` key or the header `?` icon. Esc or backdrop click closes.
+
+**Files:**
+- Create: `src/controls/helpOverlay.js`
+- Create: `src/styles/_overlay.css`
+- Modify: `index.html` (change header `?` from anchor to button; add `<dialog>` element)
+- Modify: `src/styles/_header.css` (rename `.header-methodology-link` → `.header-help-btn`)
+- Modify: `src/styles/main.css` (import `_overlay.css`)
+- Modify: `src/main.js` (call `initHelpOverlay`)
+- Modify: `src/controls/search.js` (wire `?` key inside `initKeyboardNav`)
+
+### Step 4.1 — Add the `<dialog>` markup
+
+In `index.html`, find the header `?` link (currently around line 73):
+
+```html
+<a
+  class="header-methodology-link"
+  href="/methodology.html"
+  aria-label="How countries are scored — methodology"
+  title="Methodology"
+>?</a>
+```
+
+Replace with:
+
+```html
+<button
+  id="header-help-btn"
+  class="header-help-btn"
+  type="button"
+  aria-label="Keyboard shortcuts and help"
+  title="Keyboard shortcuts"
+>?</button>
+```
+
+In `src/styles/_header.css`, rename the CSS class to match — find both selectors and replace:
+
+```css
+/* Before */
+.header-methodology-link { ... }
+.header-methodology-link:hover,
+.header-methodology-link:focus-visible { ... }
+
+/* After */
+.header-help-btn { ... }
+.header-help-btn:hover,
+.header-help-btn:focus-visible { ... }
+```
+
+Keep all property values unchanged — only the selector names change. Also drop the comment `"?" info icon next to the site title — links to methodology.html.` in favor of `"?" help button next to the site title — opens the shortcuts overlay.`
+
+Because the element is now a `<button>` instead of an `<a>`, add `cursor: pointer;` and `background: transparent;` inside the rule so it doesn't render with the default button chrome. Specifically, the rule becomes:
+
+```css
+.header-help-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-tertiary);
+  font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+  font-size: 0.66rem;
+  font-weight: 500;
+  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s var(--ease-out), border-color 0.15s var(--ease-out), background 0.15s var(--ease-out);
+  align-self: center;
+  flex-shrink: 0;
+}
+
+.header-help-btn:hover,
+.header-help-btn:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-muted);
+}
+```
+
+Then, just before `</body>` in `index.html`, add the dialog:
+
+```html
+<dialog id="help-overlay" class="help-overlay" aria-label="Keyboard shortcuts and help">
+  <div class="help-overlay-inner">
+    <button id="help-overlay-close" class="help-overlay-close" type="button" aria-label="Close">&times;</button>
+    <h2 class="help-overlay-title">Keyboard shortcuts</h2>
+    <div class="help-overlay-grid">
+      <dl>
+        <dt><kbd>/</kbd> or <kbd>&#8984;</kbd><kbd>K</kbd></dt>
+        <dd>Focus search</dd>
+        <dt><kbd>&larr;</kbd> <kbd>&rarr;</kbd></dt>
+        <dd>Step through countries</dd>
+        <dt><kbd>?</kbd></dt>
+        <dd>This menu</dd>
+      </dl>
+      <dl>
+        <dt>Click</dt>
+        <dd>Select country</dd>
+        <dt>Shift&#8239;+&#8239;click</dt>
+        <dd>Add to comparison</dd>
+        <dt><kbd>Esc</kbd></dt>
+        <dd>Close / deselect</dd>
+      </dl>
+    </div>
+    <p class="help-overlay-footer">More detail in the <a href="/methodology.html">methodology</a>.</p>
+  </div>
+</dialog>
+```
+
+### Step 4.2 — Create `src/styles/_overlay.css`
+
+Full file contents:
+
+```css
+/* ── Help overlay ─────────────────────────────────────────────
+   Native <dialog> — gives us focus trap, Esc-to-close, and
+   ::backdrop for free. Sits over the full viewport.
+   ----------------------------------------------------------- */
+.help-overlay {
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text-primary);
+  max-width: 480px;
+  width: calc(100% - 32px);
+  box-shadow: 0 20px 60px rgb(0 0 0 / 0.4);
+}
+
+.help-overlay::backdrop {
+  background: rgb(0 0 0 / 0.4);
+  backdrop-filter: blur(2px);
+}
+
+:root[data-theme='light'] .help-overlay::backdrop {
+  background: rgb(20 20 28 / 0.18);
+}
+
+.help-overlay-inner {
+  position: relative;
+  padding: 28px 32px 24px;
+}
+
+.help-overlay-title {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  margin-bottom: 18px;
+  color: var(--text-primary);
+}
+
+.help-overlay-close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s var(--ease-out), background 0.15s var(--ease-out);
+}
+
+.help-overlay-close:hover {
+  color: var(--text-primary);
+  background: var(--surface-raised);
+}
+
+.help-overlay-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px 28px;
+  margin-bottom: 20px;
+}
+
+.help-overlay-grid dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px 14px;
+  align-items: center;
+  font-size: 0.82rem;
+}
+
+.help-overlay-grid dt {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.help-overlay-grid dd {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.help-overlay-footer {
+  font-size: 0.76rem;
+  color: var(--text-tertiary);
+  padding-top: 14px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.help-overlay-footer a {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.help-overlay-footer a:hover {
+  color: var(--accent);
+}
+
+@media (max-width: 520px) {
+  .help-overlay-grid {
+    grid-template-columns: 1fr;
+  }
+}
+```
+
+### Step 4.3 — Import the overlay stylesheet
+
+In `src/styles/main.css`, append a new import at the bottom:
+
+```css
+@import './_overlay.css';
+```
+
+Result:
+
+```css
+@import './_tokens.css';
+@import './_reset.css';
+@import './_animations.css';
+@import './_header.css';
+@import './_map.css';
+@import './_panel.css';
+@import './_timeline.css';
+@import './_legend.css';
+@import './_footer.css';
+@import './_comparison.css';
+@import './_responsive.css';
+@import './_overlay.css';
+```
+
+### Step 4.4 — Create `src/controls/helpOverlay.js`
+
+Full file contents:
+
+```js
+// Help overlay — native <dialog>, showing the keyboard shortcuts that
+// already exist in src/controls/search.js. Opens via ? key (wired in
+// search.js) or the header ? button (wired here). Esc and backdrop
+// click close it for free via <dialog> semantics.
+
+export function openHelpOverlay() {
+  const dialog = document.getElementById('help-overlay');
+  if (dialog && !dialog.open && typeof dialog.showModal === 'function') {
+    dialog.showModal();
+  }
+}
+
+export function closeHelpOverlay() {
+  const dialog = document.getElementById('help-overlay');
+  if (dialog && dialog.open) dialog.close();
+}
+
+export function initHelpOverlay() {
+  const dialog = document.getElementById('help-overlay');
+  if (!dialog) return;
+
+  document.getElementById('help-overlay-close')
+    ?.addEventListener('click', closeHelpOverlay);
+
+  document.getElementById('header-help-btn')
+    ?.addEventListener('click', openHelpOverlay);
+
+  // Backdrop click — <dialog> reports the click target as the dialog
+  // itself when the user clicks outside the inner content.
+  dialog.addEventListener('click', (e) => {
+    if (e.target === dialog) closeHelpOverlay();
+  });
+}
+```
+
+### Step 4.5 — Call `initHelpOverlay` from `src/main.js`
+
+In `src/main.js`, add the import near the other control imports (around line 15):
+
+```js
+import { initHelpOverlay } from './controls/helpOverlay.js';
+```
+
+Then, inside `main()`, add the call alongside the other `init*` calls (the existing block around lines 72–81):
+
+```js
+// Wire up UI controls
+initTheme();
+buildScoreSelector();
+initFilter();
+initDimensionClicks();
+initPanel();
+initCitePopover();
+initComparison();
+initSearch();
+initKeyboardNav();
+initMapSubscriptions();
+initHelpOverlay();   // ← add this line
+```
+
+### Step 4.6 — Wire the `?` key in `src/controls/search.js`
+
+Open `src/controls/search.js` and find `initKeyboardNav` (currently starts around line 77). After the input-guard block (around line 86) and before the `/` / `Cmd+K` search-focus handler, add the `?` branch:
+
+```js
+export function initKeyboardNav() {
+  document.addEventListener('keydown', e => {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
+      if (e.key === 'Escape') {
+        e.target.blur();
+        document.getElementById('search-suggestions').replaceChildren();
+        updateSearchHighlight('');
+      }
+      return;
+    }
+
+    // ← add this block
+    if (e.key === '?') {
+      e.preventDefault();
+      const dialog = document.getElementById('help-overlay');
+      if (dialog && !dialog.open && typeof dialog.showModal === 'function') {
+        dialog.showModal();
+      }
+      return;
+    }
+    // ← end of new block
+
+    if (e.key === '/' || (e.key === 'k' && (e.metaKey || e.ctrlKey))) {
+      e.preventDefault();
+      document.getElementById('country-search').focus();
+      return;
+    }
+
+    // … rest unchanged
+```
+
+Leave everything below untouched.
+
+### Step 4.7 — Verify
+
+With the dev server still running:
+
+1. **Key opens overlay:** press `?` anywhere outside a text input → dialog appears centered, backdrop dims the map behind.
+2. **Key doesn't fire inside inputs:** focus the search input, type `?` → should insert the character, not open the overlay.
+3. **Esc closes:** with the overlay open, press Esc → dialog closes.
+4. **Backdrop click closes:** open, click outside the inner panel → closes.
+5. **Close button works:** open, click the `×` button → closes.
+6. **Header `?` button opens:** click the header `?` → opens the overlay.
+7. **Focus trap:** open the overlay, press Tab repeatedly → focus cycles through close-button, then inner links — never escapes to the map / header. This is native `<dialog>` behavior; no extra code needed.
+8. **Themes:** toggle to light theme → overlay backdrop reads as a soft dim, not opaque black; text readable. Toggle back to dark.
+9. **Methodology link:** click "More detail in the methodology" → navigates to `/methodology.html`.
+10. **Narrow viewport:** resize the browser to ~400px wide → the two-column grid collapses to one column.
+
+### Step 4.8 — Commit
+
+```bash
+git add src/controls/helpOverlay.js src/styles/_overlay.css src/styles/main.css src/styles/_header.css index.html src/main.js src/controls/search.js
+git commit -m "feat: ? help overlay listing keyboard shortcuts"
+```
+
+---
+
+## Execution order
+
+Tasks are independent except for the shared `<kbd>` styles added in Task 3 (used by Task 4). The order below serves commit hygiene, not hard dependencies:
+
+1. **Task 1 — Copy normalizer.** Most isolated. If the weekend runs short, this alone is shippable.
+2. **Task 2 — Source-count.** Tiny. Do it next so the freshness improvement lands early.
+3. **Task 3 — Empty-panel on-ramp.** Adds the shared `<kbd>` styles used by Task 4.
+4. **Task 4 — Help overlay.** Largest new surface; last.
+
+Each commit is independently revertable in reverse order.
+
+---
+
+## Non-goals / explicitly deferred
+
+- **Source-side copy fix.** Editing `scripts/regulation_pipeline/api.py` to change the LLM prompt and re-running the pipeline. That's path (A) from the brainstorm — its own plan, later. The display-layer normalizer is a holding pattern until the pipeline is retuned.
+- **Full narrative scaffolding.** Scroll-driven landing page, editorial numbered sections à la trackpolicy.org. The methodology page already covers the reference-document side; the empty-panel on-ramp covers compressed orientation. Full scaffolding is acknowledged as future work but not this weekend.
+- **Operational-freshness affordances.** Recent-activity feed, "what changed this month" ticker. These dilute the differentiator (durable structured comparison across 196 countries).
+- **Per-field confidence.** Still record-level. Per the citability plan's deferred note.
+- **New fonts, palette, animations.** Out of scope. Existing Literata + Geist + OKLCH tokens are already good.
+
+---
+
+## Success criteria
+
+- Dev server loaded cold with no country selected → empty panel shows the Literata lede, three numbered steps (01 / 02 / 03), and the "Read the methodology →" link.
+- Clicking any country → intro removed from the DOM, never returns for that page load.
+- Pressing Esc after engagement → panel shows the quiet italic "Select a country to see details." — NOT the intro.
+- Afghanistan, Angola, Antigua and Barbuda panels: descriptions no longer open with "as of [Month Year]"; cascading "No X" sentences collapsed to one.
+- Feature flag `NORMALIZE_COPY = false` in `src/constants.js` restores the raw CSV text for A/B eyeballing.
+- Country header's "Data as of …" line now includes source count (e.g. `· 3 sources`), with honest "no primary sources" fallback when empty.
+- Existing three-tier confidence badge unchanged (already shipped).
+- Pressing `?` outside an input → overlay opens. Esc / backdrop / close button all dismiss it. Works on both themes and at narrow widths.
+- No new entries in `package.json`. No changes to `public/scores.csv`, `public/regulation_data.csv`, or `public/history.json`.
+- Lighthouse accessibility score ≥ current baseline on both themes.
+
+---
+
+## Decisions (resolved during brainstorm)
+
+1. **Copy path B (display-layer), not A (source).** Source fix deserves its own plan; mixing it into weekend polish is scope creep.
+2. **Numbered on-ramp steps, not un-numbered.** Shipped first with numbers; if they read imposed ("her device pasted onto your site"), strip to three equal-weight lines in a follow-up.
+3. **Header `?` now opens overlay, not direct-to-methodology.** Methodology reaches from footer, overlay footer, and empty-panel intro. Reversible if the UX regresses.
+4. **Confidence-dot work dropped.** The three-tier confidence badge already shipped via citability Task 2.5 — verified in `src/styles/_panel.css:220-263`. Section 3 of the spec now covers source-count only.

--- a/docs/plans/2026-04-22-mobile-and-migration.md
+++ b/docs/plans/2026-04-22-mobile-and-migration.md
@@ -1,0 +1,221 @@
+# Mobile UX + Architecture Plan
+
+**Date:** 2026-04-22
+**Status:** Proposal — awaiting direction on scope and tooling.
+**Context:** The weekend polish ([2026-04-17-polish-and-onramp.md](./2026-04-17-polish-and-onramp.md)) shipped a help overlay, empty-panel on-ramp, and display-layer copy normalizer. In review, the mobile UX surfaced as the next honest weakness: a keyboard-shortcut overlay is meaningless on a phone, the empty-panel intro lives below the fold on cold load, and there's no first-class way to add a country to comparison without the desktop-only shift-click shortcut. A tactical fix has already landed (`910550d`: hide the `?` button and its intro step on coarse pointers; rewrite the intro copy). This plan scopes the fuller pass and asks whether it's the right moment to migrate off vanilla JS.
+
+---
+
+## 1. Diagnosis — what's actually broken on mobile
+
+Findings from reading the repo and the Vite preview at 375×812:
+
+| # | Problem | Severity | Where it lives |
+|---|---------|----------|----------------|
+| 1 | Empty-panel on-ramp is invisible on cold load. `#country-panel` sits below `#map-wrapper` in the flex column and `min-height: 50vh` on the map pushes the intro off-screen. | **High** | [src/styles/_responsive.css:16-31](../../src/styles/_responsive.css) |
+| 2 | No touch-first way to add a country to comparison. Desktop uses shift-click; on mobile the user has to select a country first, then tap `+ Compare`, then deselect, then select another. Nothing communicates this path. | **High** | [src/comparison/index.js](../../src/comparison/index.js), [src/panel/index.js](../../src/panel/index.js) |
+| 3 | Selecting a country doesn't scroll the panel into view — the user taps a country, "nothing happens," scrolls down to discover the panel updated. | **High** | [src/panel/index.js:123-129](../../src/panel/index.js) |
+| 4 | Comparison panel on narrow viewports: `#comparison-panel` is `min-width: 380px` and sits next to `#country-panel`. Two 380px panels on a 375px screen is a scroll overflow event. | **High** | [src/styles/_comparison.css:4](../../src/styles/_comparison.css) |
+| 5 | Header cramming: on `<768px` the header reflows to 3 rows (brand / search / score+filter+theme). It works, but the `196 countries` badge, `LAST UPDATED: YYYY-MM-DD`, and the Literata title compete for row 1. Feels busy. | Medium | [src/styles/_responsive.css:42-73](../../src/styles/_responsive.css) |
+| 6 | No back-affordance from an opened country panel. The Esc keyboard path exists; nothing touch-equivalent. | Medium | Global |
+| 7 | Timeline strip is fixed-height 50px at the bottom and takes screen real estate even when not scrubbed. On a 667px iPhone SE-class device, that's ~7.5% of vertical space gone. | Low | [src/styles/_timeline.css](../../src/styles/_timeline.css) |
+| 8 | Hit-target sizes are already bumped to 44px for score/filter/theme/dimension/search suggestions via the existing `@media (pointer: coarse)` block. Good. No action needed. | ✓ Fixed | [src/styles/_responsive.css:91-110](../../src/styles/_responsive.css) |
+| 9 | Keyboard-shortcut UI (`?` button, intro step 03) now hidden on coarse pointers. | ✓ Fixed (910550d) | [src/styles/_responsive.css](../../src/styles/_responsive.css) |
+
+**Conclusion:** problems 1–4 are blocking. Problems 5–7 are quality-of-life. The fix for 1–4 requires a new interaction model for mobile, not just CSS tuning.
+
+---
+
+## 2. Design direction — what mobile should look like
+
+Four principles, each anchored in the existing design doc (`.impeccable.md`, CLAUDE.md).
+
+### Principle A — the map stays the protagonist on mobile
+
+No hamburger-menu stowing the map behind a drawer. The map is the thing. Mobile should open to the full viewport filled with the choropleth, legend anchored bottom, header compressed to brand + search + one overflow menu.
+
+### Principle B — the panel becomes a bottom sheet, not a section below
+
+Right now the panel is a stacked section. On tap, it becomes invisible below the fold. Replace that with a bottom sheet — a native-feeling drawer that slides up on country select, covers ~60% of viewport height by default, can be dragged to ~90% for full reading, and swipes down to dismiss. Keeps the map visible in the upper portion during comparison browsing.
+
+### Principle C — explicit compare mode instead of hidden shift-click
+
+Introduce a **Compare** toggle in the header (or a floating action button at the bottom-right). Flipping it on changes selection semantics: taps add to the comparison list instead of replacing the selected country. Flipping off (or filling all four slots) drops back to normal. Desktop shift-click remains as the power-user shortcut, but no longer the only path.
+
+### Principle D — panel state is in the URL, back button dismisses
+
+A tapped country sets `?country=Germany` (already the case). On mobile, the browser back button should close the bottom sheet without leaving the page. This is a history-stack concern: the state sync needs to `pushState` for each country selection so that popstate closes the sheet. Currently `initUrlSync` uses `replaceState` — it preserves the URL but produces no navigable history.
+
+---
+
+## 3. Architecture question — stay vanilla, or migrate?
+
+The user is open to React. Worth stress-testing whether React is the right answer, or whether a smaller lever gets most of the benefit.
+
+### Current stack, honestly assessed
+
+- **~15 modules.** Small. Legible. No dependency hell.
+- **Centralized store at [src/state/store.js](../../src/state/store.js):** 40 lines, pub-sub, works. Mirrors Zustand/Redux at 1% the ceremony.
+- **D3 + SVG map renderer:** imperative, and should stay imperative — React's reconciliation over 196 SVG paths is an anti-pattern. Observable-style islands are the right fit.
+- **No test suite.** First thing a migration would expose. Vanilla-or-React, this is a hole.
+- **No TypeScript.** Free type-safety win is available without any framework change.
+
+### Migration options, sharpest-to-softest
+
+#### Option 1 — React (full)
+
+- **Pros:** ecosystem depth (react-spring for bottom-sheet physics, tanstack-router for URL-as-state, radix-ui for the help dialog we just wrote by hand), contributor accessibility, TS story is mature.
+- **Cons:** ~45 KB gzipped baseline, new build complexity, forces a wrap-or-rewrite decision for the D3 map, realistically 1–2 weeks of porting before parity.
+- **Verdict:** the right long-term answer if mobile grows into a serious target or if a second contributor joins.
+
+#### Option 2 — Preact (full)
+
+- **Pros:** same mental model as React, 3 KB gzipped, drop-in `preact/compat` supports most React libraries.
+- **Cons:** smaller ecosystem for niche libraries; `preact/compat` occasionally leaks. Still a full rewrite of the UI layer.
+- **Verdict:** rational middle path if the user wants React's mental model without the weight.
+
+#### Option 3 — Solid
+
+- **Pros:** fine-grained reactivity matches the existing pub-sub store almost exactly; fastest of the three; 7 KB.
+- **Cons:** ecosystem thinner than Preact; fewer contributors know it.
+- **Verdict:** technically elegant, socially awkward. Skip unless the user specifically likes it.
+
+#### Option 4 — Stay vanilla, add targeted libraries
+
+- Add **TypeScript** (`vite-plugin-checker`, `tsconfig` with `allowJs`) for incremental typing.
+- Add **[vaul-vanilla](https://github.com/emilkowalski/vaul)** or a 200-line hand-rolled bottom-sheet component.
+- Add **history-stack management** via a 30-line helper around `pushState`/`popstate`.
+- Keep everything else.
+- **Pros:** no migration; every fix is additive; bundle stays tiny; existing code legible.
+- **Cons:** long-tail features (dark-mode variants, search-within-descriptions, saved views) eventually hit the ceiling of vanilla composability.
+- **Verdict:** viable for 6–12 more months; the right answer right now if the mobile pass can be done without a framework.
+
+### The D3 map constraint applies to all of the above
+
+In every migration option, the map renderer ([src/map/renderer.js](../../src/map/renderer.js)) stays imperative. React wraps it in a ref-based component that updates via effect hooks on state change, never via JSX diff. This is the Observable pattern — it's fine, and it's what every serious React-D3 integration does.
+
+---
+
+## 4. Work streams
+
+Four ways to slice the work. Pick one or sequence.
+
+### Stream A — tactical mobile pass, no framework change (~1 weekend)
+
+Fixes problems 1, 3, 5, 6 without touching the stack. Leaves problem 2 (no touch-first compare) and problem 4 (side-by-side panels) for Stream B.
+
+**Deliverables:**
+- Scroll-into-view on country select when viewport is `<768px`.
+- Collapse `196 countries` badge + `LAST UPDATED` into a single line of small-caps text under the `h1`. Drop the badge visual chrome on mobile.
+- Close-button (`×`) in the country panel header on mobile, paired with the existing Esc path.
+- Hide the comparison panel entirely on `<768px` until Stream B lands a proper mobile flow. Comparison becomes desktop-only for now — honest and shippable. Add an inline note in the add-bar explaining this.
+
+**Files touched:** `_responsive.css`, `_header.css`, `_panel.css`, `_comparison.css`, `src/panel/index.js` (scroll-into-view), `index.html` (close button).
+
+**Non-goals:** no bottom sheet, no compare mode toggle, no routing changes.
+
+### Stream B — bottom-sheet + compare mode + URL history (~1 week, vanilla or Preact)
+
+Fixes problems 2 and 4. Touch-first compare mode. Bottom sheet for the country panel.
+
+**Deliverables:**
+- Bottom-sheet component for `#country-panel` on `<768px`. Three snap points (peek 25%, default 60%, expanded 90%). Drag-to-dismiss. Vaul-vanilla or hand-rolled.
+- Compare mode toggle in the header. When on, taps append to `comparisonCountries` instead of setting `selectedCountry`. Visual affordance: the selected countries show color dots on the map matching their comparison slot.
+- Full-screen comparison view on mobile (separate route: `?compare=A,B,C,D` → renders the comparison as a tab bar + single-country detail per tab, swipeable).
+- Replace `history.replaceState` with `pushState` in `initUrlSync` for country selection so the back button works as a panel-dismiss on mobile.
+
+**Decision point:** do Stream B in vanilla (add ~300 lines of gesture/sheet code to `src/controls/`) or pull in Preact now and rewrite the panel + comparison in it? Either works; the former is cheaper today, the latter pays down the Stream C path.
+
+### Stream C — React (or Preact) migration foundation (~1 week, as a proof-of-concept)
+
+Introduces React to the project without rewriting everything. Ports one component end-to-end to validate the approach.
+
+**Deliverables:**
+- Add `react` + `react-dom` (or Preact) to `package.json`. Keep Vite.
+- Add a `tsconfig.json` with `allowJs: true`, `checkJs: false`. TypeScript is a free add; JS files keep working.
+- Wrap the existing DOM in `<App />` — the root component just calls the existing vanilla init functions. This establishes a React tree without touching any existing module.
+- Port **one** component to React: the help overlay ([src/controls/helpOverlay.js](../../src/controls/helpOverlay.js)) is the cleanest candidate — self-contained, uses native `<dialog>`, no state-store integration needed. Validates the pattern.
+- Add `@testing-library/react` + Vitest. Write 3 tests for the ported overlay as the testing baseline.
+- Document the migration pattern in a `CONTRIBUTING.md` so future ports have a template.
+
+**Explicitly not in Stream C:** porting the map, the panel, the comparison, the controls. Those come in Stream D.
+
+### Stream D — full React rewrite (~2–3 weeks, optional)
+
+Only if Stream C proves out. Ports every remaining module to React. D3 map stays imperative as a ref-based island. Store becomes Zustand or stays as-is behind a `useSyncExternalStore` hook.
+
+**Deliverables:**
+- Panel, header controls, comparison, timeline, search, theme toggle — all in React.
+- URL sync moved to tanstack-router or react-router (decision based on how much the user wants file-based routing).
+- Bottom-sheet physics via [react-spring](https://www.react-spring.dev/) or [vaul](https://vaul.emilkowal.ski/).
+- Unit tests for every ported component.
+- One visual regression pass (playwright + light/dark screenshots).
+
+---
+
+## 5. Recommendation
+
+**Do Stream A now, Stream B next, defer C/D until one of these triggers fires:**
+
+1. A second contributor joins and vanilla JS becomes a recruitment friction.
+2. A feature on the backlog needs something React does well that vanilla doesn't (scroll-driven storytelling, rich comparison sorting, editable confidence annotations).
+3. The current codebase hits the 25-module ceiling where pub-sub navigation starts to feel like tribal knowledge.
+
+Today's honest answer: the site is small, the store pattern works, and the mobile problems are mostly layout + interaction-model issues that Stream A and B can solve without a framework. The best version of "migrate to React" is one that's motivated by a concrete feature need, not by an intuition that the codebase should look more like peers.
+
+**Tactical sequencing:**
+
+| When | Stream | Effort |
+|------|--------|--------|
+| This weekend | A (tactical mobile) | 1 weekend |
+| Following weekend | B part 1 (bottom sheet) | 1 weekend |
+| A month out | B part 2 (compare mode + URL history) | 1 weekend |
+| Q3 2026 or when a trigger fires | C (React foundation) | 1 week |
+| After C proves out | D (full rewrite) | 2–3 weeks |
+
+---
+
+## 6. Non-goals
+
+- **Separate mobile app.** No React Native, no PWA-to-app wrappers. Responsive web is the target.
+- **Hamburger menu.** Dismissing the map behind a drawer contradicts Principle 1 of the existing design doc.
+- **Custom gesture library.** If Stream B goes vanilla, hand-roll a small sheet component — don't pull in a 30 KB gesture framework for one bottom sheet.
+- **Mobile-only features.** Anything worth building should exist on both. If a feature only makes sense on touch (e.g. a pinch-to-reveal detail), it's not worth building.
+
+---
+
+## 7. Open questions for the user
+
+1. **Framework preference.** If Stream C runs, React or Preact? Preact gives 90% of the benefit at 5% of the bundle. React gives ecosystem depth and contributor familiarity.
+2. **Comparison flow on mobile.** Two mental models on offer: (a) full-screen swipeable country pages with a top tab bar, or (b) the existing radar-chart view unchanged, with the country chips stacking vertically. (a) reads more native; (b) is less work.
+3. **Back-button dismissal.** Pushing a history entry per country select means the back button steps through selection history. Is that the desired behavior, or should the back button exit the app / go to the previous page instead?
+4. **Scope of the empty-panel intro on mobile.** Since it's below the fold, the intro has to either (a) get a dedicated pre-map card that dismisses on first tap, or (b) get quietly dropped on mobile. (a) is more welcoming; (b) is simpler and matches the "map is protagonist" principle.
+5. **TypeScript.** Willing to add `allowJs: true` TS now regardless of Stream C? It's a free add and provides a better migration substrate.
+
+---
+
+## 8. Success criteria for each stream
+
+**Stream A done when:**
+- Tapping a country on mobile scrolls the panel into view.
+- Header on `<768px` shows brand + metadata in a single compact row.
+- Country panel has an explicit close affordance on mobile.
+- Comparison panel is cleanly hidden with an explanatory note on mobile.
+- No visual regressions on desktop (1440×900 screenshots match).
+
+**Stream B done when:**
+- Bottom sheet slides up on country tap with three snap points.
+- Compare mode toggle exists in the header; tapping countries while on adds them to comparison.
+- Browser back button closes an open panel on mobile without leaving the page.
+- Comparison page renders full-screen on mobile with a swipeable tab bar.
+
+**Stream C done when:**
+- React (or Preact) and TS are in `package.json`; Vite builds both JS and TSX.
+- The help overlay is a React component with three Vitest tests passing.
+- A `CONTRIBUTING.md` page explains the migration pattern.
+- The existing vanilla UI is visually unchanged from the user's perspective.
+
+**Stream D done when:**
+- No `src/controls/*.js` files remain — all components are TSX.
+- D3 map is a ref-based React component, mounted once.
+- A visual regression test suite exists for light and dark themes.

--- a/index.html
+++ b/index.html
@@ -156,8 +156,8 @@
       <div id="panel-intro" class="panel-intro">
         <p class="panel-intro-lede">Global AI governance across 196 countries, scored on six dimensions.</p>
         <ol class="panel-intro-steps">
-          <li><span class="panel-intro-num">01</span> Click a country to read its regulatory posture.</li>
-          <li><span class="panel-intro-num">02</span> Shift-click to compare up to four.</li>
+          <li><span class="panel-intro-num">01</span> Select a country to read its regulatory posture.</li>
+          <li><span class="panel-intro-num">02</span> Use <strong>+&nbsp;Compare</strong> to stack up to four side-by-side.</li>
           <li><span class="panel-intro-num">03</span> Press <kbd>?</kbd> for keyboard shortcuts.</li>
         </ol>
         <a class="panel-intro-methodology" href="/methodology.html">Read the methodology &rarr;</a>

--- a/index.html
+++ b/index.html
@@ -70,12 +70,13 @@
   <header id="app-header">
     <div class="header-left">
       <h1>AI Regulation Map</h1>
-      <a
-        class="header-methodology-link"
-        href="/methodology.html"
-        aria-label="How countries are scored — methodology"
-        title="Methodology"
-      >?</a>
+      <button
+        id="header-help-btn"
+        class="header-help-btn"
+        type="button"
+        aria-label="Keyboard shortcuts and help"
+        title="Keyboard shortcuts"
+      >?</button>
       <span class="header-subtitle">Last updated: <span id="site-last-updated">—</span></span>
       <span class="country-count-badge" id="country-count"></span>
     </div>
@@ -286,6 +287,32 @@
       <a href="https://github.com/riadeane" target="_blank" rel="noopener noreferrer">GitHub</a>
     </p>
   </footer>
+
+  <dialog id="help-overlay" class="help-overlay" aria-label="Keyboard shortcuts and help">
+    <div class="help-overlay-inner">
+      <button id="help-overlay-close" class="help-overlay-close" type="button" aria-label="Close">&times;</button>
+      <h2 class="help-overlay-title">Keyboard shortcuts</h2>
+      <div class="help-overlay-grid">
+        <dl>
+          <dt><kbd>/</kbd> or <kbd>&#8984;</kbd><kbd>K</kbd></dt>
+          <dd>Focus search</dd>
+          <dt><kbd>&larr;</kbd> <kbd>&rarr;</kbd></dt>
+          <dd>Step through countries</dd>
+          <dt><kbd>?</kbd></dt>
+          <dd>This menu</dd>
+        </dl>
+        <dl>
+          <dt>Click</dt>
+          <dd>Select country</dd>
+          <dt>Shift&#8239;+&#8239;click</dt>
+          <dd>Add to comparison</dd>
+          <dt><kbd>Esc</kbd></dt>
+          <dd>Close / deselect</dd>
+        </dl>
+      </div>
+      <p class="help-overlay-footer">More detail in the <a href="/methodology.html">methodology</a>.</p>
+    </div>
+  </dialog>
 
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -152,7 +152,16 @@
       ></div>
     </div>
     <aside id="country-panel">
-      <p id="no-selection-message">Select a country to see details.<br><span class="hint">Tip: Shift+click two or more countries to compare them.</span></p>
+      <div id="panel-intro" class="panel-intro">
+        <p class="panel-intro-lede">Global AI governance across 196 countries, scored on six dimensions.</p>
+        <ol class="panel-intro-steps">
+          <li><span class="panel-intro-num">01</span> Click a country to read its regulatory posture.</li>
+          <li><span class="panel-intro-num">02</span> Shift-click to compare up to four.</li>
+          <li><span class="panel-intro-num">03</span> Press <kbd>?</kbd> for keyboard shortcuts.</li>
+        </ol>
+        <a class="panel-intro-methodology" href="/methodology.html">Read the methodology &rarr;</a>
+      </div>
+      <p id="no-selection-message" class="no-selection-message" hidden>Select a country to see details.</p>
       <div id="panel-content" style="display:none">
         <div class="panel-country-header">
           <div class="panel-name-row">

--- a/src/constants.js
+++ b/src/constants.js
@@ -26,3 +26,7 @@ export const SCORE_OPTIONS = [
 ];
 
 export const PLACEHOLDER_RE = /^(na|n\/a|idem|unknown|none|\s*[-–—]\s*|\.\s*)$/i;
+
+// Display-time cleanup of LLM-generated regulation descriptions.
+// Set to false for A/B eyeballing against the raw CSV text.
+export const NORMALIZE_COPY = true;

--- a/src/controls/helpOverlay.js
+++ b/src/controls/helpOverlay.js
@@ -1,0 +1,33 @@
+// Help overlay — native <dialog>, showing the keyboard shortcuts that
+// already exist in src/controls/search.js. Opens via ? key (wired in
+// search.js) or the header ? button (wired here). Esc and backdrop
+// click close it for free via <dialog> semantics.
+
+export function openHelpOverlay() {
+  const dialog = document.getElementById('help-overlay');
+  if (dialog && !dialog.open && typeof dialog.showModal === 'function') {
+    dialog.showModal();
+  }
+}
+
+export function closeHelpOverlay() {
+  const dialog = document.getElementById('help-overlay');
+  if (dialog && dialog.open) dialog.close();
+}
+
+export function initHelpOverlay() {
+  const dialog = document.getElementById('help-overlay');
+  if (!dialog) return;
+
+  document.getElementById('help-overlay-close')
+    ?.addEventListener('click', closeHelpOverlay);
+
+  document.getElementById('header-help-btn')
+    ?.addEventListener('click', openHelpOverlay);
+
+  // Backdrop click — <dialog> reports the click target as the dialog
+  // itself when the user clicks outside the inner content.
+  dialog.addEventListener('click', (e) => {
+    if (e.target === dialog) closeHelpOverlay();
+  });
+}

--- a/src/controls/search.js
+++ b/src/controls/search.js
@@ -85,6 +85,15 @@ export function initKeyboardNav() {
       return;
     }
 
+    if (e.key === '?') {
+      e.preventDefault();
+      const dialog = document.getElementById('help-overlay');
+      if (dialog && !dialog.open && typeof dialog.showModal === 'function') {
+        dialog.showModal();
+      }
+      return;
+    }
+
     if (e.key === '/' || (e.key === 'k' && (e.metaKey || e.ctrlKey))) {
       e.preventDefault();
       document.getElementById('country-search').focus();

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import { initTimeline } from './controls/timeline.js';
 import { initTheme } from './controls/theme.js';
 import { parseUrl, initUrlSync } from './controls/url.js';
 import { initCitePopover } from './controls/citePopover.js';
+import { initHelpOverlay } from './controls/helpOverlay.js';
 import { removeMapSkeleton, showLoadError } from './panel/resilience.js';
 
 function updateSiteLastUpdated(scoreData) {
@@ -79,6 +80,7 @@ async function main() {
   initSearch();
   initKeyboardNav();
   initMapSubscriptions();
+  initHelpOverlay();
 
   // Render map
   try {

--- a/src/panel/index.js
+++ b/src/panel/index.js
@@ -92,7 +92,15 @@ function renderPanel(countryName) {
   }
 
   const dateStr = (score && score.lastUpdated) || (reg && reg.lastUpdated);
-  document.getElementById('last-updated').textContent = dateStr ? `Data as of ${dateStr}` : '';
+  const sourceUrls = reg && reg.sources
+    ? reg.sources.split('|').map(u => u.trim()).filter(Boolean)
+    : [];
+  const countText = sourceUrls.length > 0
+    ? `${sourceUrls.length} source${sourceUrls.length === 1 ? '' : 's'}`
+    : 'no primary sources';
+  document.getElementById('last-updated').textContent = dateStr
+    ? `Data as of ${dateStr} · ${countText}`
+    : countText;
 
   renderScoreBar(score ? score.averageScore : null);
   renderAllDots(score);

--- a/src/panel/index.js
+++ b/src/panel/index.js
@@ -68,7 +68,8 @@ function renderPanel(countryName) {
   const comparisonActive = comparisonCountries.length >= 2;
 
   if (!comparisonActive) {
-    document.getElementById('no-selection-message').style.display = 'none';
+    const fallback = document.getElementById('no-selection-message');
+    if (fallback) fallback.hidden = true;
     document.getElementById('panel-content').style.display = '';
   }
 
@@ -112,7 +113,8 @@ function renderPanel(countryName) {
 }
 
 function clearPanel() {
-  document.getElementById('no-selection-message').style.display = '';
+  const fallback = document.getElementById('no-selection-message');
+  if (fallback) fallback.hidden = false;
   document.getElementById('panel-content').style.display = 'none';
   clearHighlight();
   updateCompareButton();
@@ -139,4 +141,17 @@ export function initPanel() {
   on('currentAttribute', updateDimensionHighlight);
   on('comparisonCountries', () => { updateCompareButton(); updateCiteButton(); });
   updateCiteButton();
+
+  let introConsumed = false;
+  const consumeIntro = () => {
+    if (introConsumed) return;
+    const { selectedCountry, comparisonCountries } = getState();
+    if (selectedCountry || (comparisonCountries && comparisonCountries.length > 0)) {
+      introConsumed = true;
+      const intro = document.getElementById('panel-intro');
+      if (intro) intro.remove();
+    }
+  };
+  on('selectedCountry', consumeIntro);
+  on('comparisonCountries', consumeIntro);
 }

--- a/src/panel/normalize.js
+++ b/src/panel/normalize.js
@@ -1,0 +1,106 @@
+// Display-time text cleanup for LLM-generated regulation descriptions.
+//
+// Three conservative passes, each opt-out on guard. If the normalizer
+// shrinks the text below 60% of its original length or produces an empty
+// string, return the original — better stiff than factually truncated.
+//
+// CSV data is never modified. Every call is scoped to one free-text field
+// at render time in src/panel/sections.js.
+
+import { NORMALIZE_COPY } from '../constants.js';
+
+const MONTHS = 'January|February|March|April|May|June|July|August|September|October|November|December';
+
+// "Country X has no Y, as of April 2026." → strip the "as of …" clause.
+// Only applied when the phrase lives inside the first 80 characters AND
+// at least one further sentence follows. Preserves trailing "as of …"
+// which often carries legitimate anchoring mid-paragraph.
+const LEADING_TEMPORAL_RE = new RegExp(
+  `^([\\s\\S]{0,80}?)\\s*(?:,\\s*)?as of (?:${MONTHS}) \\d{4}\\s*(?=[.,])`,
+  'i'
+);
+
+// Stopwords for the cascading-negation vocabulary-overlap heuristic.
+const STOPWORDS = new Set([
+  'a','an','the','of','on','in','to','for','and','or','but','at','by','with',
+  'is','are','was','were','be','been','being','has','have','had','do','does',
+  'did','will','would','can','could','should','as','that','this','these','those',
+  'it','its','he','she','they','them','their','there','here','than','then','so',
+  'no','not','any','all','some','such','only','also','yet','from','into','over',
+  'under','about','through','between','among','per','via','nor','exist','exists'
+]);
+
+function tokens(s) {
+  return (s.toLowerCase().match(/[a-z][a-z-]+/g) || [])
+    .filter(t => !STOPWORDS.has(t) && t.length > 2);
+}
+
+function stripLeadingTemporal(text) {
+  const sentenceCount = (text.match(/[.!?](\s|$)/g) || []).length;
+  if (sentenceCount < 2) return text;
+  return text.replace(LEADING_TEMPORAL_RE, '$1').replace(/^\s*,\s*/, '').trim();
+}
+
+// Heuristic: a run of sentences all starting with "No " is redundant if
+// every sentence after the first shares ≥2 non-stopword tokens with the
+// first. Conservative — genuinely distinct claims fall through.
+function sharesVocab(sentences) {
+  const firstTokens = new Set(tokens(sentences[0]));
+  if (firstTokens.size < 2) return false;
+  for (let i = 1; i < sentences.length; i++) {
+    const shared = tokens(sentences[i]).filter(w => firstTokens.has(w)).length;
+    if (shared < 2) return false;
+  }
+  return true;
+}
+
+function collapseCascadingNegations(text) {
+  const sentences = text.match(/[^.!?]+[.!?]+\s*/g);
+  if (!sentences || sentences.length < 3) return text;
+
+  const out = [];
+  let run = [];
+
+  const flushRun = () => {
+    if (run.length >= 3 && sharesVocab(run)) {
+      out.push('No AI-specific legislation, governance body, or enforcement mechanism exists. ');
+    } else {
+      out.push(...run);
+    }
+    run = [];
+  };
+
+  for (const s of sentences) {
+    if (/^\s*No\s/.test(s)) {
+      run.push(s);
+    } else {
+      flushRun();
+      out.push(s);
+    }
+  }
+  flushRun();
+  return out.join('').trim();
+}
+
+function trimLeadingHedges(text) {
+  return text
+    .replace(/^(Generally|Broadly|Notably|Essentially|Largely),\s*/i, '')
+    .replace(/([.!?]\s+)(Generally|Broadly|Notably|Essentially|Largely),\s+/g, '$1');
+}
+
+export function normalizeRegulationText(text) {
+  if (!NORMALIZE_COPY) return text;
+  if (!text || typeof text !== 'string') return text;
+
+  const original = text;
+  let out = text;
+
+  out = stripLeadingTemporal(out);
+  out = collapseCascadingNegations(out);
+  out = trimLeadingHedges(out);
+
+  // Safety rail — never silently chew a claim into nothing.
+  if (!out || out.trim().length === 0) return original;
+  if (out.length < original.length * 0.6) return original;
+  return out;
+}

--- a/src/panel/sections.js
+++ b/src/panel/sections.js
@@ -1,4 +1,5 @@
 import { PLACEHOLDER_RE } from '../constants.js';
+import { normalizeRegulationText } from './normalize.js';
 
 export function showSection(id, show) {
   const el = document.getElementById(id);
@@ -12,7 +13,7 @@ export function cleanRegulationText(text) {
   if (PLACEHOLDER_RE.test(trimmed)) return null;
   if (/^(cf\.|Cf\.)\s/i.test(trimmed) && trimmed.length < 40) return null;
   if (/^idem\b/i.test(trimmed) && trimmed.length < 10) return null;
-  return trimmed;
+  return normalizeRegulationText(trimmed);
 }
 
 const SECTION_MAP = [

--- a/src/styles/_header.css
+++ b/src/styles/_header.css
@@ -39,10 +39,8 @@ h1 {
   text-transform: uppercase;
 }
 
-/* "?" info icon next to the site title — links to methodology.html.
-   Sized to match the surrounding header rhythm without reading as a
-   button. */
-.header-methodology-link {
+/* "?" help button next to the site title — opens the shortcuts overlay. */
+.header-help-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -50,19 +48,22 @@ h1 {
   height: 18px;
   border-radius: 50%;
   border: 1px solid var(--border);
+  background: transparent;
   color: var(--text-tertiary);
   font-family: 'Geist Mono', 'JetBrains Mono', monospace;
   font-size: 0.66rem;
   font-weight: 500;
   line-height: 1;
   text-decoration: none;
+  cursor: pointer;
+  padding: 0;
   transition: color 0.15s var(--ease-out), border-color 0.15s var(--ease-out), background 0.15s var(--ease-out);
   align-self: center;
   flex-shrink: 0;
 }
 
-.header-methodology-link:hover,
-.header-methodology-link:focus-visible {
+.header-help-btn:hover,
+.header-help-btn:focus-visible {
   color: var(--accent);
   border-color: var(--accent);
   background: var(--accent-muted);

--- a/src/styles/_overlay.css
+++ b/src/styles/_overlay.css
@@ -1,0 +1,111 @@
+/* ── Help overlay ─────────────────────────────────────────────
+   Native <dialog> — gives us focus trap, Esc-to-close, and
+   ::backdrop for free. Sits over the full viewport.
+   ----------------------------------------------------------- */
+.help-overlay {
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text-primary);
+  max-width: 480px;
+  width: calc(100% - 32px);
+  /* Restore UA centering that the global `* { margin: 0 }` reset strips. */
+  margin: auto;
+  box-shadow: 0 20px 60px rgb(0 0 0 / 0.4);
+}
+
+.help-overlay::backdrop {
+  background: rgb(0 0 0 / 0.4);
+  backdrop-filter: blur(2px);
+}
+
+:root[data-theme='light'] .help-overlay::backdrop {
+  background: rgb(20 20 28 / 0.18);
+}
+
+.help-overlay-inner {
+  position: relative;
+  padding: 28px 32px 24px;
+}
+
+.help-overlay-title {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  margin-bottom: 18px;
+  color: var(--text-primary);
+}
+
+.help-overlay-close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s var(--ease-out), background 0.15s var(--ease-out);
+}
+
+.help-overlay-close:hover {
+  color: var(--text-primary);
+  background: var(--surface-raised);
+}
+
+.help-overlay-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px 28px;
+  margin-bottom: 20px;
+}
+
+.help-overlay-grid dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px 14px;
+  align-items: center;
+  font-size: 0.82rem;
+}
+
+.help-overlay-grid dt {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.help-overlay-grid dd {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.help-overlay-footer {
+  font-size: 0.76rem;
+  color: var(--text-tertiary);
+  padding-top: 14px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.help-overlay-footer a {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.help-overlay-footer a:hover {
+  color: var(--accent);
+}
+
+@media (max-width: 520px) {
+  .help-overlay-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/styles/_panel.css
+++ b/src/styles/_panel.css
@@ -23,20 +23,74 @@
   border-radius: 3px;
 }
 
-#no-selection-message {
-  color: var(--text-tertiary);
-  font-style: italic;
-  font-size: 0.82rem;
-  padding: 32px 24px;
-  line-height: 1.6;
+/* ── Empty-panel on-ramp ──────────────────────────────────────
+   Shown once, on first load, before any country is selected.
+   Removed from the DOM on first engagement (see src/panel/index.js).
+   After that, #no-selection-message takes over as a quiet one-liner.
+   ----------------------------------------------------------- */
+.panel-intro {
+  padding: 28px 22px 24px;
+  max-width: 320px;
 }
 
-#no-selection-message .hint {
-  display: inline-block;
-  margin-top: 10px;
+.panel-intro-lede {
+  font-family: 'Literata', Georgia, serif;
+  font-size: 1.15rem;
+  font-weight: 400;
+  line-height: 1.35;
+  color: var(--text-primary);
+  letter-spacing: -0.005em;
+  margin-bottom: 22px;
+}
+
+.panel-intro-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel-intro-steps li {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.panel-intro-num {
+  font-family: 'Geist Mono', ui-monospace, monospace;
   font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
   color: var(--text-tertiary);
-  font-style: normal;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+  min-width: 1.8em;
+}
+
+.panel-intro-methodology {
+  display: inline-block;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 1px;
+  transition: color 0.15s var(--ease-out), border-color 0.15s var(--ease-out);
+}
+
+.panel-intro-methodology:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.no-selection-message {
+  padding: 24px 22px;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  font-style: italic;
 }
 
 .panel-country-header {

--- a/src/styles/_reset.css
+++ b/src/styles/_reset.css
@@ -120,3 +120,23 @@ input:focus-visible,
   text-decoration: underline;
   text-underline-offset: 3px;
 }
+
+/* Keyboard-key pill. Shared by the empty-panel on-ramp and the help
+   overlay. Small monospace badge; inherits color from the surrounding
+   text so it reads quiet. */
+kbd {
+  display: inline-block;
+  min-width: 1.4em;
+  padding: 0 0.4em;
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.82em;
+  font-weight: 500;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  vertical-align: baseline;
+}

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -107,4 +107,16 @@
     display: flex;
     align-items: center;
   }
+
+  /* Keyboard-shortcut UI is meaningless on a touchscreen. Hide the
+     header trigger and the intro step that explains it. The ? key
+     handler stays intact so paired Bluetooth keyboards on tablets
+     still work. */
+  .header-help-btn {
+    display: none;
+  }
+
+  .panel-intro-steps li:has(kbd) {
+    display: none;
+  }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9,3 +9,4 @@
 @import './_footer.css';
 @import './_comparison.css';
 @import './_responsive.css';
+@import './_overlay.css';


### PR DESCRIPTION
## Summary

Ships the weekend polish plan ([docs/plans/2026-04-17-polish-and-onramp.md](docs/plans/2026-04-17-polish-and-onramp.md)), a tactical mobile fix surfaced during review, and a new proposal for the fuller mobile pass + React-migration question.

## What changed

**Weekend polish (four independent commits):**
- `dd55c53` **Copy normalizer** — three conservative passes at render time: strip leading "as of Month YYYY" clauses when the field has two or more sentences, collapse cascading "No X" sentences that share vocabulary, drop leading hedges. Safety rail returns the original text whenever the output would shrink below 60% of source. Flag `NORMALIZE_COPY` in `src/constants.js` disables the transform for A/B eyeballing. CSV data untouched.
- `851f1af` **Source-count in date line** — `Data as of 2026-03-21 · 3 sources` (with honest `no primary sources` fallback when empty).
- `5967e40` **Empty-panel on-ramp** — Literata lede, three numbered steps, methodology link in the empty country panel. DOM-removed on first engagement; a quiet italic one-liner takes its place on subsequent deselects.
- `153ab8e` **`?` help overlay** — native `<dialog>` listing the keyboard shortcuts the app already wires. Opens via `?` key or header `?` button; Esc / backdrop / close button all dismiss. Added `margin: auto` to restore UA centering the global `* { margin: 0 }` reset was stripping.

**Tactical mobile fix:**
- `910550d` Hide the `?` header button and the intro step that explains it on `(pointer: coarse)`. The `?` keydown handler stays so paired Bluetooth keyboards on tablets still work. Intro copy rewritten for pointer-agnostic verbs — "Select" instead of "Click"; "Use **+ Compare** to stack up to four side-by-side" instead of "Shift-click". Non-breaking space in `+ Compare` to avoid mid-label wrap at narrow widths.

**Docs:**
- `e665809` The spec and plan that drove the polish work, plus a new proposal at [docs/plans/2026-04-22-mobile-and-migration.md](docs/plans/2026-04-22-mobile-and-migration.md) diagnosing nine mobile issues, laying out four design principles (map-first / bottom sheet / explicit compare mode / URL-as-navigation), and breaking the architecture question into four work streams (tactical → bottom-sheet → React foundation → full rewrite). Recommends streams A and B now, defers C/D until a concrete feature or contributor triggers a migration rather than moving on intuition.

## Test plan

- [x] Dev server: cold load with no country selected shows the Literata lede + 01/02/03 steps + methodology link on desktop
- [x] Engage a country → intro removed from DOM; Esc → quiet italic one-liner appears, intro does not return
- [x] Algeria / Belarus / Antigua show stripped "as of April 2026"; Germany / France / Argentina unchanged; Angola correctly falls through the 80-char guard
- [x] `Data as of … · N source(s)` verified for 0 (Afghanistan), 1 (Albania), 2 (Australia) sources
- [x] `?` key and header `?` button both open overlay; Esc / backdrop click / close button all dismiss; centered on both themes; grid collapses to one column at <520px
- [x] `?` key suppressed while a text input has focus
- [x] Compiled stylesheet confirms `.header-help-btn { display: none }` and `.panel-intro-steps li:has(kbd) { display: none }` under `@media (pointer: coarse)`
- [ ] Real device: verify hide behavior on an actual phone (preview's mobile preset resizes viewport but doesn't emulate touch, so `pointer: coarse` does not match in the preview)

## Reviewer notes

- The help-overlay centering fix (`margin: auto` on `.help-overlay`) is easy to miss but necessary — without it the global reset pins the dialog to top-left.
- `NORMALIZE_COPY` was deliberately left as an in-code flag rather than a URL param — the plan is to remove it once the source-side prompt fix lands, at which point the display-layer normalizer becomes unnecessary.
- The mobile plan at `docs/plans/2026-04-22-mobile-and-migration.md` is a **proposal, not a commitment**. No work from it is included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)