### PR TITLE
UX review fixes: map, panel, filtering, and accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
       </div>
       <div id="score-btn-container">
         <button id="score-btn" aria-haspopup="listbox" aria-expanded="false">
-          <span id="score-btn-label">Average Score</span>
+          <span id="score-btn-label">Maturity Index</span>
           <span class="caret">▾</span>
         </button>
         <ul id="score-dropdown" role="listbox" aria-label="Score type"></ul>
@@ -121,7 +121,7 @@
           </div>
         </div>
       </div>
-      <button id="scatter-btn" aria-pressed="false" title="Dimension explorer — cross-dimension scatter view">Explorer</button>
+      <button id="scatter-btn" aria-pressed="false" title="Dimension explorer — plot every country across two score dimensions">Scatter</button>
       <div id="export-btn-container">
         <button id="export-btn" aria-haspopup="true" aria-expanded="false">
           Export <span class="caret">▾</span>
@@ -182,7 +182,7 @@
     </div>
     <aside id="country-panel">
       <div id="panel-intro" class="panel-intro">
-        <p class="panel-intro-lede">Global AI governance across 196 countries, scored on six dimensions.</p>
+        <p class="panel-intro-lede">Global AI governance across <span id="intro-country-count">196</span> countries, scored on six dimensions.</p>
         <ol class="panel-intro-steps">
           <li><span class="panel-intro-num">01</span> Select a country to read its regulatory posture.</li>
           <li><span class="panel-intro-num">02</span> Use <strong>+&nbsp;Compare</strong> to stack up to four side-by-side.</li>
@@ -219,7 +219,7 @@
           ></div>
         </div>
         <div class="panel-section">
-          <div class="panel-section-label">OVERALL SCORE</div>
+          <div class="panel-section-label">MATURITY INDEX</div>
           <div class="score-bar-row">
             <div class="score-bar-track">
               <div class="score-bar-fill" id="overall-bar-fill"></div>
@@ -231,26 +231,51 @@
         <div class="panel-section">
           <div class="panel-section-label">DIMENSIONS</div>
           <div class="dimensions-list">
-            <button type="button" class="dimension-row" data-dimension="regulationStatus">
-              <span class="dim-label">Regulation Status</span>
-              <span class="dim-dots" id="dots-regulation"></span>
-            </button>
-            <button type="button" class="dimension-row" data-dimension="policyLever">
-              <span class="dim-label">Policy Lever</span>
-              <span class="dim-dots" id="dots-policy"></span>
-            </button>
-            <button type="button" class="dimension-row" data-dimension="governanceType">
-              <span class="dim-label">Governance Type</span>
-              <span class="dim-dots" id="dots-governance"></span>
-            </button>
-            <button type="button" class="dimension-row" data-dimension="actorInvolvement">
-              <span class="dim-label">Actor Involvement</span>
-              <span class="dim-dots" id="dots-actors"></span>
-            </button>
-            <button type="button" class="dimension-row" data-dimension="enforcementLevel">
-              <span class="dim-label">Enforcement Level</span>
-              <span class="dim-dots" id="dots-enforcement"></span>
-            </button>
+            <div class="dimension-row" data-dimension="regulationStatus">
+              <button type="button" class="dim-main">
+                <span class="dim-label">Regulation Status</span>
+                <span class="dim-dots" id="dots-regulation"></span>
+              </button>
+              <button type="button" class="dim-expand" aria-expanded="false" aria-label="Show Regulation Status sub-indicators">
+                <span class="dim-expand-caret" aria-hidden="true">▸</span>
+              </button>
+            </div>
+            <div class="dimension-row" data-dimension="policyLever">
+              <button type="button" class="dim-main">
+                <span class="dim-label">Policy Lever</span>
+                <span class="dim-dots" id="dots-policy"></span>
+              </button>
+              <button type="button" class="dim-expand" aria-expanded="false" aria-label="Show Policy Lever sub-indicators">
+                <span class="dim-expand-caret" aria-hidden="true">▸</span>
+              </button>
+            </div>
+            <div class="dimension-row" data-dimension="governanceType">
+              <button type="button" class="dim-main">
+                <span class="dim-label">Governance Type</span>
+                <span class="dim-dots" id="dots-governance"></span>
+              </button>
+              <button type="button" class="dim-expand" aria-expanded="false" aria-label="Show Governance Type sub-indicators">
+                <span class="dim-expand-caret" aria-hidden="true">▸</span>
+              </button>
+            </div>
+            <div class="dimension-row" data-dimension="actorInvolvement">
+              <button type="button" class="dim-main">
+                <span class="dim-label">Actor Involvement</span>
+                <span class="dim-dots" id="dots-actors"></span>
+              </button>
+              <button type="button" class="dim-expand" aria-expanded="false" aria-label="Show Actor Involvement sub-indicators">
+                <span class="dim-expand-caret" aria-hidden="true">▸</span>
+              </button>
+            </div>
+            <div class="dimension-row" data-dimension="enforcementLevel">
+              <button type="button" class="dim-main">
+                <span class="dim-label">Enforcement Level</span>
+                <span class="dim-dots" id="dots-enforcement"></span>
+              </button>
+              <button type="button" class="dim-expand" aria-expanded="false" aria-label="Show Enforcement Level sub-indicators">
+                <span class="dim-expand-caret" aria-hidden="true">▸</span>
+              </button>
+            </div>
           </div>
         </div>
         <p id="no-details-message" class="panel-section" style="display:none; color: var(--text-secondary); font-size: 0.8rem; font-style: italic;">
@@ -321,8 +346,9 @@
 
   <div id="timeline-strip" style="display:none">
     <div id="timeline-inner">
+      <span class="timeline-title">History</span>
       <button id="timeline-reset" type="button" aria-label="Jump to latest date" title="Jump to latest">&#x21BA;</button>
-      <input type="range" id="timeline-slider" min="0" max="0" step="1" value="0" aria-label="Timeline date slider">
+      <input type="range" id="timeline-slider" min="0" max="0" step="1" value="0" aria-label="Scrub AI regulation scores back through monthly snapshots">
       <span id="timeline-date-label">Latest</span>
     </div>
   </div>

--- a/public/methodology.html
+++ b/public/methodology.html
@@ -347,7 +347,7 @@
     <h2 id="the-six-dimensions">The six dimensions</h2>
     <p>
       Each country is scored on five dimensions, plus a composite
-      <strong>average score</strong> shown by default. Three dimensions
+      <strong>maturity index</strong> shown by default. Three dimensions
       (regulation status, policy lever, enforcement level) are
       <em>normative</em>: higher means more developed. Two
       (governance type, actor involvement) are <em>descriptive</em>:
@@ -392,7 +392,7 @@
     </div>
 
     <h3>Governance Type</h3>
-    <p>Where authority for AI regulation sits — concentrated in a single body vs. distributed across agencies, sectors, and levels of government. <strong>Descriptive, not a quality scale:</strong> a 1 here means highly centralized, not bad; a 5 means highly distributed, not good. This dimension does not enter the average score.</p>
+    <p>Where authority for AI regulation sits — concentrated in a single body vs. distributed across agencies, sectors, and levels of government. <strong>Descriptive, not a quality scale:</strong> a 1 here means highly centralized, not bad; a 5 means highly distributed, not good. This dimension does not enter the maturity index.</p>
     <div class="rubric">
       <div class="rubric-row"><div class="rubric-score">1</div><div class="rubric-body">Centralized: a single national authority sets and enforces policy.</div></div>
       <div class="rubric-row"><div class="rubric-score">2</div><div class="rubric-body">Lead authority with informal delegation to one or two sectoral bodies; coordination happens ad hoc.</div></div>
@@ -402,7 +402,7 @@
     </div>
 
     <h3>Actor Involvement</h3>
-    <p>Which actors shape AI policy — narrow expert circles vs. broad engagement with industry, civil society, academia, and the public. <strong>Descriptive, not a quality scale</strong>, and scored on domestic process: international standard-setting activity does not substitute for civil-society access at home. This dimension does not enter the average score.</p>
+    <p>Which actors shape AI policy — narrow expert circles vs. broad engagement with industry, civil society, academia, and the public. <strong>Descriptive, not a quality scale</strong>, and scored on domestic process: international standard-setting activity does not substitute for civil-society access at home. This dimension does not enter the maturity index.</p>
     <div class="rubric">
       <div class="rubric-row"><div class="rubric-score">1</div><div class="rubric-body">Limited: policy is set inside government with minimal external input.</div></div>
       <div class="rubric-row"><div class="rubric-score">2</div><div class="rubric-body">Industry is consulted informally; civil society and academia have no structured access.</div></div>
@@ -421,8 +421,8 @@
       <div class="rubric-row"><div class="rubric-score">5</div><div class="rubric-body">Active enforcement: penalties have been issued, audits are routine, and a dedicated authority publishes enforcement actions.</div></div>
     </div>
 
-    <h3>Average Score</h3>
-    <p>A <strong>regulatory maturity index</strong>: the arithmetic mean of the three normative dimensions — regulation status, policy lever, and enforcement level. Governance type and actor involvement are excluded because they describe regulatory <em>style</em>, not development; averaging them in would reward or punish countries for being centralized or distributed. Shown by default on the map because it gives the fastest cross-country read, but the individual dimensions are where the interesting signal lives.</p>
+    <h3>Maturity Index</h3>
+    <p>A <strong>regulatory maturity index</strong> (the arithmetic mean of the three normative dimensions — regulation status, policy lever, and enforcement level), labelled <em>Maturity Index</em> on the map and exported as the <code>Average Score</code> column. Governance type and actor involvement are excluded because they describe regulatory <em>style</em>, not development; averaging them in would reward or punish countries for being centralized or distributed. Shown by default on the map because it gives the fastest cross-country read, but the individual dimensions are where the interesting signal lives.</p>
     <div class="callout"><strong>Continuity note:</strong> Before June 2026 the composite averaged four dimensions (including the two descriptive ones, excluding enforcement) and all scores were integers. Comparisons across that boundary should use the per-dimension scores, which kept their definitions.</div>
 
     <h2 id="confidence">Confidence levels</h2>

--- a/src/comparison/index.ts
+++ b/src/comparison/index.ts
@@ -116,6 +116,10 @@ export function initComparison(): void {
     }
   });
 
+  // Remember what had focus when the full view took over, so closing it
+  // can hand focus back rather than dropping it on a now-hidden element.
+  let focusBeforeView: HTMLElement | null = null;
+
   on('comparisonViewOpen', (open) => {
     document.body.classList.toggle('view-compare', open);
     updateStrip();
@@ -123,13 +127,22 @@ export function initComparison(): void {
     if (open) {
       // Comparison and the scatter explorer both claim the main area.
       if (getState().scatterOpen) setState({ scatterOpen: false });
+      focusBeforeView = document.activeElement as HTMLElement | null;
       if (panelEl) panelEl.hidden = false;
       if (countryPanelEl) countryPanelEl.style.display = 'none';
       renderComparisonPanel(getState().comparisonCountries);
+      // The country panel may have just been hidden — move focus into
+      // the new region so keyboard users aren't stranded.
+      backBtn?.focus();
     } else {
       if (panelEl) panelEl.hidden = true;
       if (countryPanelEl) countryPanelEl.style.display = '';
       clearComparisonPanel();
+      // Restore focus to the opener if it's still on-screen.
+      if (focusBeforeView && document.contains(focusBeforeView) && focusBeforeView.offsetParent !== null) {
+        focusBeforeView.focus();
+      }
+      focusBeforeView = null;
     }
   });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const ATTRIBUTE_LABELS = {
-  averageScore: 'Average Score',
+  averageScore: 'Maturity Index',
   regulationStatus: 'Regulation Status',
   policyLever: 'Policy Lever',
   governanceType: 'Governance Type',
@@ -23,7 +23,7 @@ export const LEGEND_ENDPOINTS: Record<AttributeKey, [string, string]> = {
 };
 
 export const SCORE_OPTIONS: { value: AttributeKey; text: string }[] = [
-  { value: 'averageScore',     text: 'Average Score' },
+  { value: 'averageScore',     text: 'Maturity Index' },
   { value: 'regulationStatus', text: 'Regulation Status' },
   { value: 'policyLever',      text: 'Policy Lever' },
   { value: 'governanceType',   text: 'Governance Type' },

--- a/src/controls/blocSelector.ts
+++ b/src/controls/blocSelector.ts
@@ -42,7 +42,10 @@ export function initBlocSelector(): void {
   });
 
   row.append(label, select);
-  popover.appendChild(row);
+  // Keep the reset button (appended by initFilter) last in the popover.
+  const resetRow = popover.querySelector('.filter-reset-row');
+  if (resetRow) popover.insertBefore(row, resetRow);
+  else popover.appendChild(row);
 
   select.value = getState().selectedBloc || '';
 }

--- a/src/controls/export.ts
+++ b/src/controls/export.ts
@@ -59,6 +59,27 @@ function downloadFile(content: string, filename: string, mimeType: string): void
   URL.revokeObjectURL(url);
 }
 
+let toastTimer: ReturnType<typeof setTimeout> | undefined;
+
+// Transient confirmation so the download isn't silent — and so the
+// researcher can see which scope (filtered vs all) they actually got.
+// Doubles as an aria-live announcement for screen-reader users.
+function showToast(message: string): void {
+  let toast = document.getElementById('app-toast');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'app-toast';
+    toast.className = 'app-toast';
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    document.body.appendChild(toast);
+  }
+  toast.textContent = message;
+  toast.classList.add('visible');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => toast!.classList.remove('visible'), 2800);
+}
+
 function exportData(format: string, allCountries: boolean): void {
   const countries = allCountries
     ? Object.keys(getState().scoreData).sort()
@@ -71,6 +92,10 @@ function exportData(format: string, allCountries: boolean): void {
   } else {
     downloadFile(JSON.stringify(rows, null, 2), `ai-regulation-data-${scope}-${date}.json`, 'application/json');
   }
+  showToast(
+    `Exported ${rows.length} ${rows.length === 1 ? 'country' : 'countries'} · ` +
+    `${allCountries ? 'all countries' : 'filtered view'} · ${format.toUpperCase()}`
+  );
 }
 
 export function initExport(): void {

--- a/src/controls/filter.ts
+++ b/src/controls/filter.ts
@@ -1,4 +1,4 @@
-import { setState } from '../state/store';
+import { getState, setState, on } from '../state/store';
 
 export function initFilter(): void {
   const btn = document.getElementById('filter-btn')!;
@@ -32,4 +32,47 @@ export function initFilter(): void {
 
   minSlider.addEventListener('input', applyFilter);
   maxSlider.addEventListener('input', applyFilter);
+
+  // Reset affordance — a narrowed map greys most countries, and there
+  // was no one-click way back. Appended last so the async-loaded bloc
+  // row (blocSelector.ts) can insert itself above it.
+  const resetRow = document.createElement('div');
+  resetRow.className = 'filter-reset-row';
+  const resetBtn = document.createElement('button');
+  resetBtn.type = 'button';
+  resetBtn.className = 'filter-reset';
+  resetBtn.textContent = 'Reset filters';
+  resetBtn.addEventListener('click', () => {
+    minSlider.value = '1';
+    maxSlider.value = '5';
+    minLabel.textContent = '1';
+    maxLabel.textContent = '5';
+    setState({ filterMin: 1, filterMax: 5, selectedBloc: null });
+  });
+  resetRow.appendChild(resetBtn);
+  popover.appendChild(resetRow);
+
+  // Persistent active-state signal: when the score range is narrowed or
+  // a bloc is selected, the button carries a dot + accent border so the
+  // narrowed view is legible with the popover closed. Subscribes to the
+  // state (not just slider input) so URL navigation and the bloc
+  // dropdown keep it in sync.
+  function updateActiveState() {
+    const { filterMin, filterMax, selectedBloc, blocsData } = getState();
+    const rangeActive = filterMin > 1 || filterMax < 5;
+    const blocActive = !!selectedBloc;
+    const active = rangeActive || blocActive;
+    btn.classList.toggle('has-filter', active);
+    resetBtn.disabled = !active;
+    const parts: string[] = [];
+    if (rangeActive) parts.push(`scores ${filterMin}–${filterMax}`);
+    if (blocActive) parts.push(blocsData?.[selectedBloc!]?.name || selectedBloc!);
+    btn.title = active ? `Active filter: ${parts.join(' · ')}` : '';
+  }
+
+  on('filterMin', updateActiveState);
+  on('filterMax', updateActiveState);
+  on('selectedBloc', updateActiveState);
+  on('blocsData', updateActiveState);
+  updateActiveState();
 }

--- a/src/controls/scoreSelector.ts
+++ b/src/controls/scoreSelector.ts
@@ -46,13 +46,20 @@ export function buildScoreSelector(): void {
 }
 
 export function initDimensionClicks(): void {
-  // Rows are real <button> elements now — Enter/Space activation comes
-  // free from the browser, so we only wire click. Clicking a row colors
-  // the map by that dimension; clicking the active row again toggles
-  // back to the maturity index (there was no in-panel way back before).
+  // Each dimension row has two distinct controls: the main button
+  // recolors the map by that dimension (this handler), and a separate
+  // caret button discloses the sub-indicator breakdown (see
+  // panel/subscores.ts). They were a single overloaded click target
+  // before — one click did both, with contradictory signifiers.
+  //
+  // Clicking the main button colors the map by that dimension; clicking
+  // the active dimension again toggles back to the maturity index
+  // (there was no in-panel way back before).
   document.querySelectorAll<HTMLElement>('.dimension-row[data-dimension]').forEach(row => {
-    row.title = 'Color the map by this dimension — click again to return to the maturity index';
-    row.addEventListener('click', () => {
+    const main = row.querySelector<HTMLElement>('.dim-main');
+    if (!main) return;
+    main.title = 'Color the map by this dimension — click again to return to the maturity index';
+    main.addEventListener('click', () => {
       const dimension = row.dataset.dimension as AttributeKey;
       switchAttribute(getState().currentAttribute === dimension ? 'averageScore' : dimension);
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,10 @@ function updateCountryCount(scoreData: ScoreData): void {
   const count = Object.keys(scoreData).length;
   const el = document.getElementById('country-count');
   if (el) el.textContent = `${count} countries`;
+  // Keep the intro lede's count in sync with the data rather than a
+  // hardcoded number that silently drifts.
+  const introCount = document.getElementById('intro-country-count');
+  if (introCount) introCount.textContent = String(count);
 }
 
 function closeAllDropdowns(e: MouseEvent): void {

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -19,12 +19,33 @@ function announceMode() {
   region.textContent = `Map now showing ${label}. Legend ranges from ${low} to ${high}.`;
 }
 
+// Speak the selected country and its current-mode score. Country paths
+// aren't individually focusable, so search and arrow-stepping are the
+// keyboard paths into the map — without this, those users get no
+// feedback on what they landed on.
+function announceCountry(name: string | null) {
+  const region = document.getElementById('map-live-region');
+  if (!region) return;
+  if (!name) {
+    region.textContent = 'Selection cleared.';
+    return;
+  }
+  const { scoreData, currentAttribute } = getState();
+  const label = ATTRIBUTE_LABELS[currentAttribute] || currentAttribute;
+  const score = scoreData[name]?.[currentAttribute];
+  region.textContent = score != null
+    ? `Selected ${name}. ${label}: ${score} of 5.`
+    : `Selected ${name}. No ${label} data.`;
+}
+
 export function initMapSubscriptions() {
   on('currentAttribute', () => {
     updateMap();
     updateLegendLabels();
     announceMode();
   });
+
+  on('selectedCountry', announceCountry);
 
   on('filterMin', () => updateMap());
   on('filterMax', () => updateMap());

--- a/src/map/legend.ts
+++ b/src/map/legend.ts
@@ -76,6 +76,29 @@ export function addLegend(
     .attr('y', legendHeight - legendMargin.bottom + 4)
     .attr('text-anchor', 'end')
     .text(endpoints[1]);
+
+  // "No data" key — countries with no score render in --no-data grey,
+  // and without this the reader can't tell "no information" from a low
+  // score (or from a country filtered out of the current view).
+  const noData = legend.append('g')
+    .attr('class', 'legend-nodata')
+    .attr('transform', 'translate(0, -13)');
+
+  noData.append('rect')
+    .attr('width', 9)
+    .attr('height', 9)
+    .attr('y', -8)
+    .attr('rx', 2)
+    .style('fill', cssVar('--no-data'))
+    .attr('stroke', cssVar('--border'))
+    .attr('stroke-width', 0.5);
+
+  noData.append('text')
+    .attr('class', 'legend-label')
+    .attr('x', 14)
+    .attr('y', 0)
+    .attr('text-anchor', 'start')
+    .text('No data');
 }
 
 export function updateLegendLabels(): void {

--- a/src/map/tooltip.ts
+++ b/src/map/tooltip.ts
@@ -15,10 +15,27 @@ export function createTooltip(): void {
 
 export function showTooltip(event: MouseEvent, html: string): void {
   if (!tooltipEl) createTooltip();
-  tooltipEl!.transition().duration(200).style('opacity', 0.9);
-  tooltipEl!.html(html)
-    .style('left', (event.pageX + 12) + 'px')
-    .style('top', (event.pageY - 28) + 'px');
+  const el = tooltipEl!;
+  // Set content first so the box is measured at its real size, then
+  // position it. Default is down-right of the cursor; flip toward the
+  // cursor when the box would overflow the right or bottom edge.
+  el.html(html);
+  const node = el.node()!;
+  const { width, height } = node.getBoundingClientRect();
+  const pad = 12;
+  const vw = document.documentElement.clientWidth;
+  const vh = document.documentElement.clientHeight;
+
+  let left = event.pageX + pad;
+  if (event.clientX + pad + width > vw) left = event.pageX - width - pad;
+  if (left < window.scrollX + 2) left = window.scrollX + 2;
+
+  let top = event.pageY - 28;
+  if (event.clientY - 28 + height > vh) top = event.pageY - height - pad;
+  if (top < window.scrollY + 2) top = window.scrollY + 2;
+
+  el.transition().duration(200).style('opacity', 0.9);
+  el.style('left', left + 'px').style('top', top + 'px');
 }
 
 export function hideTooltip(): void {

--- a/src/panel/scores.ts
+++ b/src/panel/scores.ts
@@ -4,13 +4,25 @@ export function renderDots(elId: string, score: number | null): void {
   const el = document.getElementById(elId);
   if (!el) return;
   el.replaceChildren();
+  // Scores carry quarter-point decimals since methodology v2. Fill whole
+  // dots up to the integer part, then partially fill the next dot for the
+  // fraction — rounding (e.g. 1.75 → two full dots) overstated the score.
+  const s = score ?? 0;
+  const whole = Math.floor(s);
+  const frac = s - whole;
   for (let i = 1; i <= 5; i++) {
     const dot = document.createElement('span');
-    dot.className = i <= Math.round(score as number) ? 'dim-dot filled' : 'dim-dot';
+    if (i <= whole) {
+      dot.className = 'dim-dot filled';
+    } else if (i === whole + 1 && frac > 0) {
+      dot.className = 'dim-dot partial';
+      dot.style.setProperty('--fill', `${Math.round(frac * 100)}%`);
+    } else {
+      dot.className = 'dim-dot';
+    }
     el.appendChild(dot);
   }
-  // Scores carry quarter-point decimals since methodology v2 — the
-  // dots round, the number carries the precision.
+  // The number beside the dots carries the exact value.
   if (score != null) {
     const value = document.createElement('span');
     value.className = 'dim-score-value';

--- a/src/panel/subscores.ts
+++ b/src/panel/subscores.ts
@@ -67,13 +67,29 @@ function renderBreakdown(container: HTMLElement, dimension: DimensionKey): boole
 function collapseAll(): void {
   expanded = null;
   document.querySelectorAll<HTMLElement>('.subscore-panel').forEach(p => { p.hidden = true; });
-  document.querySelectorAll('.dimension-row').forEach(r => r.setAttribute('aria-expanded', 'false'));
+  document.querySelectorAll('.dim-expand').forEach(b => b.setAttribute('aria-expanded', 'false'));
+}
+
+// Hide the disclosure caret on rows that have no audit trail for the
+// current country — a control that opens nothing is worse than no
+// control. Runs when the country changes and when subscores.json lands.
+function updateExpandAvailability(): void {
+  const { subscores, selectedCountry } = getState();
+  const entry = subscores && selectedCountry ? subscores.countries[selectedCountry] : null;
+  document.querySelectorAll<HTMLElement>('.dimension-row[data-dimension]').forEach(row => {
+    const btn = row.querySelector<HTMLButtonElement>('.dim-expand');
+    if (!btn) return;
+    const snake = DIMENSION_TO_SNAKE[row.dataset.dimension as Exclude<DimensionKey, never>];
+    btn.hidden = !(entry && entry[snake]);
+  });
 }
 
 export function initSubscores(): void {
   document.querySelectorAll<HTMLElement>('.dimension-row[data-dimension]').forEach(row => {
-    row.setAttribute('aria-expanded', 'false');
-    row.addEventListener('click', () => {
+    const expandBtn = row.querySelector<HTMLButtonElement>('.dim-expand');
+    if (!expandBtn) return;
+    expandBtn.setAttribute('aria-expanded', 'false');
+    expandBtn.addEventListener('click', () => {
       const dimension = row.dataset.dimension as DimensionKey;
       const panel = panelFor(row);
 
@@ -84,12 +100,14 @@ export function initSubscores(): void {
       collapseAll();
       if (renderBreakdown(panel, dimension)) {
         panel.hidden = false;
-        row.setAttribute('aria-expanded', 'true');
+        expandBtn.setAttribute('aria-expanded', 'true');
         expanded = dimension;
       }
     });
   });
 
-  // New country: values change, so collapse rather than show stale data.
-  on('selectedCountry', collapseAll);
+  // New country: values change, so collapse rather than show stale data,
+  // and re-evaluate which rows actually have a breakdown to show.
+  on('selectedCountry', () => { collapseAll(); updateExpandAvailability(); });
+  on('subscores', updateExpandAvailability);
 }

--- a/src/scatter/index.ts
+++ b/src/scatter/index.ts
@@ -209,8 +209,15 @@ export function initScatter(): void {
     // own the main area.
     if (opening && getState().comparisonViewOpen) setState({ comparisonViewOpen: false });
     setState({ scatterOpen: opening });
+    // Move focus into the explorer so keyboard users land in the new
+    // view (and back to the trigger when it closes). Only on explicit
+    // toggles — not on load / URL restore, which call setVisible directly.
+    if (opening) closeBtn.focus();
   });
-  closeBtn.addEventListener('click', () => setState({ scatterOpen: false }));
+  closeBtn.addEventListener('click', () => {
+    setState({ scatterOpen: false });
+    btn.focus();
+  });
 
   on('scatterOpen', setVisible);
 

--- a/src/styles/_comparison.css
+++ b/src/styles/_comparison.css
@@ -511,6 +511,20 @@ body.view-compare .radar-chart svg {
     height: 32px;
     font-size: 1.1rem;
   }
+
+  /* Narrower columns let two or three countries fit without horizontal
+     scroll on a phone; prose wraps rather than the table crushing it.
+     Four countries still scroll — acknowledged in renderComparisonTable. */
+  .comparison-table td {
+    min-width: 148px;
+  }
+  .ct-label {
+    width: 96px;
+  }
+  .comparison-table th,
+  .comparison-table td {
+    padding: 12px 12px 12px 0;
+  }
 }
 
 @media (pointer: coarse) {

--- a/src/styles/_header.css
+++ b/src/styles/_header.css
@@ -250,6 +250,54 @@ h1 {
   color: var(--accent);
 }
 
+/* Persistent "a filter is applied" signal — visible even when the
+   popover is closed. A leading accent dot + accent border, but no
+   filled background, so it reads as "active" without mimicking the
+   open (.active) state. */
+#filter-btn.has-filter {
+  border-color: var(--accent);
+}
+
+#filter-btn.has-filter::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
+/* Reset row at the foot of the filter popover. */
+.filter-reset-row {
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 4px;
+  padding-top: 12px;
+}
+
+.filter-reset {
+  width: 100%;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: 'Geist', -apple-system, sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  padding: 7px 10px;
+  cursor: pointer;
+  transition: border-color 0.15s var(--ease-out), color 0.15s var(--ease-out);
+}
+
+.filter-reset:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.filter-reset:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .caret {
   font-size: 0.65em;
   opacity: 0.5;

--- a/src/styles/_map.css
+++ b/src/styles/_map.css
@@ -20,8 +20,8 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(ellipse at center, transparent 50%, var(--bg) 100%);
-  opacity: 0.4;
+  background: radial-gradient(ellipse at center, transparent 60%, var(--bg) 100%);
+  opacity: 0.25;
   z-index: 1;
 }
 

--- a/src/styles/_overlay.css
+++ b/src/styles/_overlay.css
@@ -109,3 +109,42 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Transient toast ──────────────────────────────────────────
+   Bottom-center confirmation (currently used by data export). Doubles
+   as an aria-live region for screen readers.
+   ----------------------------------------------------------- */
+.app-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%) translateY(8px);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 16px;
+  font-family: 'Geist', -apple-system, sans-serif;
+  font-size: 0.78rem;
+  color: var(--text-primary);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
+  font-variant-numeric: tabular-nums;
+  z-index: 1100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s var(--ease-out), transform 0.2s var(--ease-out);
+}
+
+.app-toast.visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-toast {
+    transition: opacity 0.2s var(--ease-out);
+    transform: translateX(-50%);
+  }
+  .app-toast.visible {
+    transform: translateX(-50%);
+  }
+}

--- a/src/styles/_panel.css
+++ b/src/styles/_panel.css
@@ -177,7 +177,9 @@
 
 .score-bar-fill {
   height: 100%;
-  background: linear-gradient(90deg, var(--score-low), var(--accent));
+  /* Same low→high ramp as the choropleth so a given score reads the
+     same color here as it does on the map. */
+  background: linear-gradient(90deg, var(--score-low), var(--score-high));
   border-radius: 2px;
   transition: width 0.5s var(--ease-out);
   width: 0%;
@@ -191,7 +193,7 @@
   top: -1px;
   width: 6px;
   height: 6px;
-  background: var(--accent);
+  background: var(--score-high);
   border-radius: 50%;
 }
 
@@ -212,30 +214,15 @@
   gap: 10px;
 }
 
+/* A row holds two distinct controls: the main button recolors the map
+   by this dimension; the trailing caret discloses the sub-indicator
+   breakdown. Keeping them as separate targets (not one overloaded
+   click) is the whole point. */
 .dimension-row {
-  /* Reset native <button> appearance so it inherits the panel's type
-     treatment. The element is a real button (keyboard, disabled, etc.
-     all come free) but looks like a row. */
-  appearance: none;
-  -webkit-appearance: none;
-  background: transparent;
-  border: 0;
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  width: calc(100% + 16px);
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 8px;
-  margin: -6px -8px;
+  align-items: stretch;
+  gap: 2px;
   border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: background 0.15s var(--ease-out);
-}
-
-.dimension-row:hover {
-  background: var(--accent-muted);
 }
 
 .dimension-row.active-dimension {
@@ -245,6 +232,67 @@
 .dimension-row.active-dimension .dim-label {
   color: var(--accent);
   font-weight: 500;
+}
+
+/* Primary target — color the map by this dimension. */
+.dim-main {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.15s var(--ease-out);
+}
+
+.dim-main:hover {
+  background: var(--accent-muted);
+}
+
+/* Secondary target — disclose the sub-indicator audit trail. */
+.dim-expand {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 0 7px;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s var(--ease-out), color 0.15s var(--ease-out);
+}
+
+.dim-expand:hover {
+  background: var(--accent-muted);
+  color: var(--accent);
+}
+
+.dim-expand[hidden] {
+  display: none;
+}
+
+.dim-expand-caret {
+  font-size: 0.6rem;
+  line-height: 1;
+  transition: transform 0.15s var(--ease-out);
+}
+
+.dim-expand[aria-expanded='true'] .dim-expand-caret {
+  transform: rotate(90deg);
+  color: var(--accent);
 }
 
 .dim-label {
@@ -280,6 +328,12 @@
 
 .dim-dot.filled {
   background: var(--accent);
+}
+
+/* Fractional dot — the quarter-point part of a v2 score, filled
+   left-to-right so a 1.75 reads as one full dot plus a three-quarter dot. */
+.dim-dot.partial {
+  background: linear-gradient(90deg, var(--accent) var(--fill, 50%), var(--border) var(--fill, 50%));
 }
 
 /* Confidence badge — always visible at high/medium/low, but visual
@@ -322,9 +376,12 @@
 }
 
 .confidence-badge[data-level='low'] {
-  color: var(--accent);
-  background: var(--accent-muted);
-  border-color: color-mix(in oklch, var(--accent) 30%, transparent);
+  /* A caution hue distinct from the brand accent — accent means
+     "interactive / selected" everywhere else, so a warning shouldn't
+     borrow it. Red-leaning so low confidence reads louder than medium. */
+  color: oklch(64% 0.19 28);
+  background: oklch(64% 0.19 28 / 0.12);
+  border-color: oklch(64% 0.19 28 / 0.30);
 }
 
 /* Panel header actions row — Compare + Cite sit side by side. */
@@ -677,19 +734,4 @@
 
 .changelog-note a {
   color: var(--text-secondary);
-}
-
-/* Disclosure caret — the dimension rows expand to sub-indicators, and
-   nothing else hints at that. */
-.dimension-row[aria-expanded]::after {
-  content: '▸';
-  font-size: 0.6rem;
-  color: var(--text-tertiary);
-  margin-left: 8px;
-  transition: transform 0.15s var(--ease-out);
-  flex-shrink: 0;
-}
-
-.dimension-row[aria-expanded='true']::after {
-  transform: rotate(90deg);
 }

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -109,6 +109,10 @@
     min-height: 44px;
   }
 
+  .dim-expand {
+    min-width: 44px;
+  }
+
   #search-suggestions li {
     min-height: 44px;
     display: flex;

--- a/src/styles/_timeline.css
+++ b/src/styles/_timeline.css
@@ -11,6 +11,18 @@
   gap: 14px;
 }
 
+/* Without a label the scrubber reads as an anonymous slider; this names
+   it so a first-time user knows it steps through historical snapshots. */
+.timeline-title {
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 #timeline-reset {
   background: none;
   border: 1px solid var(--border);


### PR DESCRIPTION
Resolves the findings from a full UX review of the app. Each change is a local, low-risk fix — no architectural changes. Typecheck, lint, all 67 unit tests, and the production build pass.

## Top findings

- **Overloaded dimension-row click** — one click previously fired two unrelated actions (recolor the map *and* expand the sub-indicator breakdown) with contradictory signifiers. Split into two distinct controls: the main button recolors the map; a separate caret discloses the breakdown (and hides on rows with no audit trail).
- **Invisible filter state** — the score-range filter silently greyed most of the map with no closed-state signal and no way back. Added a persistent active-filter indicator (accent dot + border) on the Filter button and a **Reset filters** button.
- **Color inconsistency** — the panel's overall score bar filled toward the brand accent, so "high" read as a different color than the map's blue. Unified it with the choropleth's low→high ramp.
- **One metric, three names** — "Average Score" / "Overall Score" / "Maturity index" were the same number. Standardised on **Maturity Index** across the selector, panel, tooltip, and methodology (the data/export column stays `Average Score` as a data contract, noted explicitly in the methodology).
- **No-data legend key** — added a "No data" swatch so muted-grey countries are explained, not confused with low scores or filtered-out countries.

## Also fixed

- Tooltip flips toward the cursor near the right/bottom viewport edges instead of clipping.
- Softer map vignette so edge geographies stay legible.
- Low-confidence badge now uses a distinct caution hue instead of the brand accent (which means "interactive" everywhere else).
- Dimension dots render a partial fill for the fractional score instead of rounding (1.75 → one full dot + a ¾ dot).
- Timeline scrubber labelled "History"; intro lede uses the live country count instead of a hardcoded number.
- Data exports confirm with a toast (also an aria-live announcement of the scope).
- "Explorer" button renamed to the more self-describing "Scatter".
- Tighter comparison table on phones so 2–3 countries fit before horizontal scroll.

## Accessibility

- The live region now announces the selected country and its score, so search / arrow-key users get feedback.
- Focus moves into the comparison view on open and is restored on close; focus moves into the scatter view and back to its trigger.
- 44px touch targets preserved on the new split dimension controls.

## Deferred (with rationale)

- **Full keyboard/AT operation of map regions** (focusable country paths or a parallel data table) — a real feature with design decisions attached; the new selection announcement narrows the gap, but the rest is a good standalone follow-up.
- **Red-as-value-judgment** in the divergent ramp — left as a conscious choice the methodology already addresses, rather than re-coloring the established scale.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 67/67 pass
- `npm run build` — succeeds

https://claude.ai/code/session_012JZGDwhRR7ymM6NEy8qnAS

---
_Generated by [Claude Code](https://claude.ai/code/session_012JZGDwhRR7ymM6NEy8qnAS)_