### PR TITLE
Skip map resize fits while full-screen views hide the map

### DIFF
--- a/src/map/renderer.ts
+++ b/src/map/renderer.ts
@@ -56,6 +56,24 @@ function readContainerSize(): Size {
   return { w, h };
 }
 
+// True while a full-screen view has the map hidden: the scatter explorer
+// dims #map via visibility, the comparison view drops #map-wrapper via
+// display:none. Both also toggle #timeline-strip, which changes the map
+// box. A ResizeObserver fire in that window would re-fit the projection
+// to a transient size the map never actually shows at — then the stale
+// fit flashes ("zooms") the instant the view closes and the map repaints.
+// Skip those fits; closing the view changes the box again and re-fires
+// the observer, fitting to the real size.
+function mapIsHidden(): boolean {
+  const wrapper = document.getElementById('map-wrapper');
+  const mapEl = document.getElementById('map');
+  if (!wrapper || !mapEl) return true;
+  // display:none on the wrapper (comparison view) → no layout box.
+  if (wrapper.clientWidth === 0 || wrapper.clientHeight === 0) return true;
+  // visibility:hidden on the map layer (scatter explorer).
+  return getComputedStyle(mapEl).visibility === 'hidden';
+}
+
 // Fit the projection so the map fills as much of the container as it
 // reasonably can without lopping off whole regions.
 //
@@ -246,6 +264,7 @@ export async function generateMap(): Promise<void> {
       pending = true;
       requestAnimationFrame(() => {
         pending = false;
+        if (mapIsHidden()) return;
         fitToSize(readContainerSize());
       });
     });


### PR DESCRIPTION
## Summary

Prevents visual glitches ("zoom flashes") when closing full-screen views (scatter explorer, comparison view) by skipping ResizeObserver-triggered map projection fits while the map element is hidden.

## Changes

- Added `mapIsHidden()` function to detect when the map is hidden via:
  - `display:none` on `#map-wrapper` (comparison view)
  - `visibility:hidden` on `#map` (scatter explorer)
  - Missing DOM elements (safety check)
  
- Modified the ResizeObserver callback in `generateMap()` to skip `fitToSize()` when `mapIsHidden()` returns true

## Implementation Details

When a full-screen view opens, it hides the map and toggles `#timeline-strip`, which changes the map container's layout box. The ResizeObserver fires during this transition and would fit the projection to a transient, incorrect size. When the view closes, the observer fires again with the correct size.

By skipping fits while hidden, we avoid the stale projection fit that would flash/zoom when the map repaints. The subsequent observer fire (when the view closes and the map is visible again) applies the correct fit.

https://claude.ai/code/session_01YDFSHy4X4WvC8QhjPjj7jb