### PR TITLE
Fix timeline playback: carry earliest snapshot backward for all countries

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -31,12 +31,21 @@ export function buildScoresAtDate(
 ): Record<string, HistorySnapshot> {
   const result: Record<string, HistorySnapshot> = {};
   for (const [country, snapshots] of Object.entries(history.countries)) {
-    const applicable = snapshots
-      .filter(s => s.date <= targetDate)
-      .sort((a, b) => b.date.localeCompare(a.date));
-    if (applicable.length > 0) {
-      result[country] = applicable[0];
+    if (snapshots.length === 0) continue;
+    // Snapshots are change-points — the pipeline only appends a new one
+    // when a score actually changes (see history.py) — so they describe a
+    // step function. The latest snapshot on or before targetDate holds.
+    // Before a country's first snapshot there is no recorded change, so we
+    // carry its earliest known state backward rather than dropping it;
+    // otherwise countries vanish from the map the moment you scrub past the
+    // date they were first researched.
+    const ordered = [...snapshots].sort((a, b) => a.date.localeCompare(b.date));
+    let chosen = ordered[0];
+    for (const snapshot of ordered) {
+      if (snapshot.date > targetDate) break;
+      chosen = snapshot;
     }
+    result[country] = chosen;
   }
   return result;
 }

--- a/src/map/renderer.ts
+++ b/src/map/renderer.ts
@@ -275,7 +275,12 @@ export async function generateMap(): Promise<void> {
 // Single opacity composition for the score-range filter and the bloc
 // filter. (Search dimming stays class-based in CSS and intentionally
 // wins over this inline value while the user is mid-search.)
+//
+// `country` is the geometry's name, which is also the key `entry` was
+// looked up under — use it for the bloc test rather than entry.country,
+// since historical snapshots (timeline playback) carry no country field.
 function countryOpacity(
+  country: string,
   entry: MapScoreEntry | undefined,
   { currentAttribute, filterMin, filterMax, blocSet }: {
     currentAttribute: AttributeKey;
@@ -291,7 +296,7 @@ function countryOpacity(
   }
   const score = entry[currentAttribute]!;
   const inRange = score >= filterMin && score <= filterMax;
-  const inBloc = !blocSet || blocSet.has((entry as ScoreEntry).country);
+  const inBloc = !blocSet || blocSet.has(country);
   return (inRange && inBloc) ? 1 : 0.15;
 }
 
@@ -311,7 +316,7 @@ export function updateMap(overrideScoreData?: MapScores): void {
       const entry = data[d.properties.name];
       return entry ? colorScale(entry[currentAttribute] as number) : cssVar('--no-data');
     })
-    .style('opacity', d => countryOpacity(data[d.properties.name], {
+    .style('opacity', d => countryOpacity(d.properties.name, data[d.properties.name], {
       currentAttribute, filterMin, filterMax, blocSet,
     }));
 }

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -26,10 +26,15 @@ describe('buildScoresAtDate', () => {
     expect(result.Germany.regulationStatus).toBe(5);
   });
 
-  it('omits countries with no snapshot before the target date', () => {
+  it('carries the earliest snapshot backward before a country first appears', () => {
+    // Algeria's first snapshot is 2026-04-01. Scrubbing earlier than that
+    // must not make it vanish from the map — we show its earliest known
+    // state rather than dropping it (snapshots are change-points, so there
+    // is no recorded change before the first one).
     const result = buildScoresAtDate(history, '2026-03-25');
-    expect(result.Germany).toBeDefined();
-    expect(result.Algeria).toBeUndefined();
+    expect(result.Germany.regulationStatus).toBe(4);
+    expect(result.Algeria).toBeDefined();
+    expect(result.Algeria.regulationStatus).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary

When scrubbing the timeline to dates before a country's first recorded snapshot, the country now displays its earliest known state rather than vanishing from the map. This fixes a UX issue where countries would disappear during timeline playback simply because they hadn't been researched yet at that historical date.

## Changes

- **`src/data/history.ts`**: Refactored `buildScoresAtDate()` to always return the earliest snapshot for each country, even when the target date precedes all snapshots. Added detailed comments explaining that snapshots are change-points (the pipeline only appends when a score changes), so they describe a step function. Before a country's first snapshot, we carry its earliest known state backward rather than dropping it.

- **`tests/history.test.js`**: Updated test case from "omits countries with no snapshot before the target date" to "carries the earliest snapshot backward before a country first appears". Changed assertions to verify that Algeria is present with its earliest known regulation status (2) when scrubbing to 2026-03-25, before its first snapshot on 2026-04-01.

- **`src/map/renderer.ts`**: Fixed `countryOpacity()` function to accept `country` (the geometry's name) as a parameter and use it for bloc membership testing instead of `entry.country`. This is necessary because historical snapshots from timeline playback carry no country field. Updated the function call in `updateMap()` to pass the country name explicitly.

## Implementation Details

The key insight is that snapshots represent change-points in the data pipeline—a new snapshot is only appended when a score actually changes. This means they describe a step function where the value is constant between snapshots. For dates before the first snapshot, the correct behavior is to show the earliest known state (the first snapshot's values), not to omit the country entirely.

The bloc filtering fix ensures that timeline playback works correctly with bloc-based filtering, since historical data doesn't include the country field that current score entries have.

https://claude.ai/code/session_018Ap4eDWPMpTmEvdra4Q3iJ