### PR TITLE
Mobile sheet layout for country details + responsive header

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,11 @@
         </div>
       </div>
       <div id="zoom-controls"></div>
+      <div id="mobile-hint" class="mobile-hint" hidden>
+        <span>Tap a country to explore</span>
+        <a href="/methodology.html">Methodology</a>
+        <button id="mobile-hint-close" class="mobile-hint-close" type="button" aria-label="Dismiss hint">&times;</button>
+      </div>
       <div id="bloc-summary" class="bloc-summary" hidden></div>
       <div id="scatter-container" class="scatter-container" hidden>
         <div class="scatter-header">
@@ -337,6 +342,7 @@
           <span class="strip-count"><span id="comparison-strip-count">0</span>/4</span>
         </div>
         <div id="tray-chips" class="strip-chips"></div>
+        <div id="tray-add" class="strip-add"></div>
         <button id="tray-view-btn" class="strip-view-btn" type="button" disabled>View comparison</button>
       </div>
     </aside>

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
       ></div>
     </div>
     <aside id="country-panel">
-      <div id="sheet-grabber" class="sheet-grabber" aria-hidden="true"></div>
+      <button id="sheet-grabber" class="sheet-grabber" type="button" aria-label="Close country details"></button>
       <div id="panel-intro" class="panel-intro">
         <p class="panel-intro-lede">Global AI governance across <span id="intro-country-count">196</span> countries, scored on six dimensions.</p>
         <ol class="panel-intro-steps">

--- a/index.html
+++ b/index.html
@@ -181,6 +181,7 @@
       ></div>
     </div>
     <aside id="country-panel">
+      <div id="sheet-grabber" class="sheet-grabber" aria-hidden="true"></div>
       <div id="panel-intro" class="panel-intro">
         <p class="panel-intro-lede">Global AI governance across <span id="intro-country-count">196</span> countries, scored on six dimensions.</p>
         <ol class="panel-intro-steps">

--- a/index.html
+++ b/index.html
@@ -81,8 +81,21 @@
         aria-label="Keyboard shortcuts and help"
         title="Keyboard shortcuts"
       >?</button>
-      <span class="header-subtitle">Last updated: <span id="site-last-updated">—</span></span>
-      <span class="country-count-badge" id="country-count"></span>
+      <button
+        id="menu-toggle"
+        class="menu-toggle"
+        type="button"
+        aria-label="Show controls"
+        aria-expanded="false"
+      >
+        <svg class="menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+          <path d="M4 7h16M4 12h16M4 17h16"></path>
+        </svg>
+      </button>
+      <div class="header-meta">
+        <span class="header-subtitle">Last updated: <span id="site-last-updated">—</span></span>
+        <span class="country-count-badge" id="country-count"></span>
+      </div>
     </div>
     <div class="header-right">
       <div id="search-container">

--- a/src/comparison/panel.ts
+++ b/src/comparison/panel.ts
@@ -18,7 +18,9 @@ const DETAIL_DIMENSIONS: DimensionKey[] = [
 // comparison. Much faster than hunting for a country on the map.
 // Clicking a country on the map still works; that path hands the
 // most recent click to the "quick add" button alongside the search.
-function buildSearchInput(atCap: boolean): HTMLDivElement {
+// `listId` must be unique per instance — the full-view add-bar and the
+// staging strip both mount one, and duplicate ids break aria-controls.
+export function buildSearchInput(atCap: boolean, listId = 'comp-search-suggestions'): HTMLDivElement {
   const wrap = document.createElement('div');
   wrap.className = 'comp-search';
 
@@ -31,11 +33,11 @@ function buildSearchInput(atCap: boolean): HTMLDivElement {
   input.autocomplete = 'off';
   input.setAttribute('aria-label', 'Search country to add to comparison');
   input.setAttribute('aria-autocomplete', 'list');
-  input.setAttribute('aria-controls', 'comp-search-suggestions');
+  input.setAttribute('aria-controls', listId);
   input.disabled = atCap;
 
   const list = document.createElement('ul');
-  list.id = 'comp-search-suggestions';
+  list.id = listId;
   list.className = 'comp-search-suggestions';
   list.setAttribute('role', 'listbox');
 
@@ -168,6 +170,25 @@ export function renderTray(names: string[]): void {
   const btn = document.getElementById('tray-view-btn') as HTMLButtonElement;
   chips.replaceChildren();
   names.forEach(name => chips.appendChild(buildChip(name)));
+
+  // Add-a-country search, mounted once in the staging strip so the set can
+  // be built without hunting the map for the 2nd–4th country. Kept in
+  // sync with the cap; recreating it would drop focus mid-type.
+  const addSlot = document.getElementById('tray-add');
+  if (addSlot) {
+    const atCap = names.length >= MAX_COMPARISON;
+    let input = addSlot.querySelector<HTMLInputElement>('.comp-search-input');
+    if (!input) {
+      addSlot.appendChild(buildSearchInput(atCap, 'strip-comp-search-suggestions'));
+      input = addSlot.querySelector<HTMLInputElement>('.comp-search-input');
+    }
+    if (input) {
+      input.disabled = atCap;
+      input.placeholder = atCap
+        ? `Max ${MAX_COMPARISON} reached — remove one first`
+        : 'Add a country to compare…';
+    }
+  }
 
   btn.disabled = names.length < 2;
   btn.textContent = names.length < 2

--- a/src/controls/menu.ts
+++ b/src/controls/menu.ts
@@ -1,12 +1,15 @@
 // Mobile-only "controls" menu. The ☰ toggle folds the secondary header
-// controls (filter, scatter, export, theme) and the freshness metadata
-// away so the map keeps the screen; tapping it reveals them. On desktop
-// the button is hidden and the full toolbar shows inline, so the toggled
-// `controls-open` class has no effect there (the hide rules live inside
-// the mobile media query).
+// controls (filter, scatter, export) away so the map keeps the screen;
+// tapping it reveals them. The theme toggle and the freshness metadata
+// stay OUT of the menu (persistent theme + trust signal). On desktop the
+// button is hidden and the full toolbar shows inline, so the toggled
+// `controls-open` class has no effect there.
+
+import { on } from '../state/store';
 
 export function initMenu(): void {
   const btn = document.getElementById('menu-toggle');
+  const header = document.getElementById('app-header');
   if (!btn) return;
 
   const setOpen = (open: boolean): void => {
@@ -18,4 +21,20 @@ export function initMenu(): void {
   btn.addEventListener('click', () => {
     setOpen(!document.body.classList.contains('controls-open'));
   });
+
+  // Auto-close when the user taps outside the header (map, sheet,
+  // timeline) — otherwise the expanded toolbar stays pinned over the map
+  // for the rest of the session. Clicks on the toolbar popovers count as
+  // inside, since they're anchored within #app-header.
+  document.addEventListener('click', (e) => {
+    if (!document.body.classList.contains('controls-open')) return;
+    if (header && header.contains(e.target as Node)) return;
+    setOpen(false);
+  });
+
+  // Selecting a country (sheet) or opening a full view takes over the
+  // screen, so collapse the menu rather than leave it hanging.
+  on('selectedCountry', (name) => { if (name) setOpen(false); });
+  on('scatterOpen', (open) => { if (open) setOpen(false); });
+  on('comparisonViewOpen', (open) => { if (open) setOpen(false); });
 }

--- a/src/controls/menu.ts
+++ b/src/controls/menu.ts
@@ -1,0 +1,21 @@
+// Mobile-only "controls" menu. The ☰ toggle folds the secondary header
+// controls (filter, scatter, export, theme) and the freshness metadata
+// away so the map keeps the screen; tapping it reveals them. On desktop
+// the button is hidden and the full toolbar shows inline, so the toggled
+// `controls-open` class has no effect there (the hide rules live inside
+// the mobile media query).
+
+export function initMenu(): void {
+  const btn = document.getElementById('menu-toggle');
+  if (!btn) return;
+
+  const setOpen = (open: boolean): void => {
+    document.body.classList.toggle('controls-open', open);
+    btn.setAttribute('aria-expanded', String(open));
+    btn.setAttribute('aria-label', open ? 'Hide controls' : 'Show controls');
+  };
+
+  btn.addEventListener('click', () => {
+    setOpen(!document.body.classList.contains('controls-open'));
+  });
+}

--- a/src/controls/onboarding.ts
+++ b/src/controls/onboarding.ts
@@ -1,0 +1,38 @@
+// First-run hint for touch users. On the sheet layout the desktop intro
+// panel is off-screen (it lives inside the not-yet-open sheet), so a
+// first-timer gets an unlabelled map. This shows a single dismissible
+// hint, once, and retires it on the first real engagement.
+
+import { on, getState } from '../state/store';
+
+const KEY = 'mobileHintDismissed';
+
+function isSheetLayout(): boolean {
+  return typeof window.matchMedia === 'function'
+    && window.matchMedia('(max-width: 768px), (max-height: 500px) and (pointer: coarse)').matches;
+}
+
+export function initOnboarding(): void {
+  const hint = document.getElementById('mobile-hint');
+  const closeBtn = document.getElementById('mobile-hint-close');
+  if (!hint) return;
+
+  let dismissed = false;
+  try { dismissed = localStorage.getItem(KEY) === '1'; } catch { /* storage blocked */ }
+
+  const { selectedCountry, comparisonCountries } = getState();
+  const alreadyEngaged = !!selectedCountry || (comparisonCountries?.length ?? 0) > 0;
+  if (!dismissed && isSheetLayout() && !alreadyEngaged) {
+    hint.hidden = false;
+  }
+
+  const dismiss = (): void => {
+    hint.hidden = true;
+    try { localStorage.setItem(KEY, '1'); } catch { /* storage blocked */ }
+  };
+
+  closeBtn?.addEventListener('click', dismiss);
+  // Any real engagement retires the hint (and remembers it).
+  on('selectedCountry', (name) => { if (name) dismiss(); });
+  on('comparisonCountries', (names) => { if (Array.isArray(names) && names.length) dismiss(); });
+}

--- a/src/controls/search.ts
+++ b/src/controls/search.ts
@@ -71,6 +71,19 @@ export function initSearch(): void {
         .slice(0, TEXT_LIMIT)
       : [];
 
+    // Nothing matched: clear the highlight to null — NOT an empty set,
+    // which would mark every country "dimmed" and fade the whole map to
+    // 8% — and show an explicit empty state instead of a vanished box.
+    if (countryMatches.length === 0 && textMatches.length === 0) {
+      updateSearchHighlight(null);
+      const empty = document.createElement('li');
+      empty.className = 'search-empty';
+      empty.setAttribute('role', 'presentation');
+      empty.textContent = `No countries or policies match “${query}”`;
+      suggestions.appendChild(empty);
+      return;
+    }
+
     updateSearchHighlight(new Set([
       ...countryMatches,
       ...textMatches.map(m => m.country),

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { parseUrl, initUrlSync } from './controls/url';
 import { initCitePopover } from './controls/citePopover';
 import { initHelpOverlay } from './controls/helpOverlay';
 import { initMenu } from './controls/menu';
+import { initOnboarding } from './controls/onboarding';
 import { removeMapSkeleton, showLoadError } from './panel/resilience';
 import type { ScoreData, RegulationData } from './data/loader';
 
@@ -102,6 +103,7 @@ async function main(): Promise<void> {
   initScatter();
   initHelpOverlay();
   initMenu();
+  initOnboarding();
 
   if (urlState.scatter) {
     setState({

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import { initTheme } from './controls/theme';
 import { parseUrl, initUrlSync } from './controls/url';
 import { initCitePopover } from './controls/citePopover';
 import { initHelpOverlay } from './controls/helpOverlay';
+import { initMenu } from './controls/menu';
 import { removeMapSkeleton, showLoadError } from './panel/resilience';
 import type { ScoreData, RegulationData } from './data/loader';
 
@@ -100,6 +101,7 @@ async function main(): Promise<void> {
   initMapSubscriptions();
   initScatter();
   initHelpOverlay();
+  initMenu();
 
   if (urlState.scatter) {
     setState({

--- a/src/map/legend.ts
+++ b/src/map/legend.ts
@@ -82,16 +82,15 @@ export function addLegend(
   // score (or from a country filtered out of the current view).
   const noData = legend.append('g')
     .attr('class', 'legend-nodata')
-    .attr('transform', 'translate(0, -13)');
+    .attr('transform', 'translate(0, -11)');
 
-  noData.append('rect')
-    .attr('width', 9)
-    .attr('height', 9)
-    .attr('y', -8)
-    .attr('rx', 2)
-    .style('fill', cssVar('--no-data'))
-    .attr('stroke', cssVar('--border'))
-    .attr('stroke-width', 0.5);
+  // A filled dot (no outline) reads as a colour key; the old bordered
+  // square read as an unchecked checkbox.
+  noData.append('circle')
+    .attr('cx', 4)
+    .attr('cy', -4)
+    .attr('r', 4.5)
+    .style('fill', cssVar('--no-data'));
 
   noData.append('text')
     .attr('class', 'legend-label')

--- a/src/map/renderer.ts
+++ b/src/map/renderer.ts
@@ -137,7 +137,7 @@ export async function generateMap(): Promise<void> {
   const svg = select('#map')
     .append<SVGSVGElement>('svg')
     .attr('role', 'img')
-    .attr('aria-label', 'World map showing AI regulation scores by country. Click a country for details; Shift+click to compare.')
+    .attr('aria-label', 'World map showing AI regulation scores by country. Select a country for its profile.')
     .attr('width', size.w)
     .attr('height', size.h)
     .attr('viewBox', [0, 0, size.w, size.h])

--- a/src/map/renderer.ts
+++ b/src/map/renderer.ts
@@ -238,6 +238,24 @@ export async function generateMap(): Promise<void> {
   zoomHandle = setupZoom(svg, mapGroup, () => currentSize);
   addLegend(svg, colorScale, size);
 
+  // Tap anywhere that ISN'T a country (ocean, sphere edge, graticule, bare
+  // svg) to deselect — the click-away that closes the mobile sheet and
+  // clears the selection on desktop. A country's own handler owns its
+  // clicks. Guard against the click that fires at the end of a pan by
+  // ignoring it when the pointer travelled since it went down.
+  let downX = 0;
+  let downY = 0;
+  svg.on('pointerdown.deselect', (event: PointerEvent) => {
+    downX = event.clientX;
+    downY = event.clientY;
+  });
+  svg.on('click.deselect', (event: MouseEvent) => {
+    if (Math.hypot(event.clientX - downX, event.clientY - downY) > 6) return;
+    const target = event.target as Element | null;
+    if (target?.classList?.contains('country')) return;
+    if (getState().selectedCountry) setState({ selectedCountry: null });
+  });
+
   onThemeChange(() => {
     const refreshed = makeColorScale();
     const { scoreData: sd, currentAttribute: attr } = getState();

--- a/src/map/tooltip.ts
+++ b/src/map/tooltip.ts
@@ -13,7 +13,17 @@ export function createTooltip(): void {
     .style('opacity', 0);
 }
 
+// Devices without hover fire synthetic mouseover on tap, which would
+// strand this tooltip on-screen (and it carries desktop-only hints like
+// "Shift+click"). Suppress it there; touch users get identity from the
+// sheet (map) and the tap-to-identify flow (scatter) instead.
+function canHover(): boolean {
+  return typeof window.matchMedia !== 'function'
+    || window.matchMedia('(hover: hover)').matches;
+}
+
 export function showTooltip(event: MouseEvent, html: string): void {
+  if (!canHover()) return;
   if (!tooltipEl) createTooltip();
   const el = tooltipEl!;
   // Set content first so the box is measured at its real size, then

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -135,10 +135,11 @@ function renderPanel(countryName: string): void {
   updateCompareButton();
   updateCiteButton();
 
-  // On phones the panel sits below the map — without this, tapping a
-  // country appears to do nothing (April 2026 mobile diagnosis, #3).
-  if (!comparisonViewOpen && window.matchMedia('(max-width: 768px)').matches) {
-    document.getElementById('country-panel')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  // On phones the panel is a bottom sheet layered over the map. Selecting
+  // a country slides it up (the transition lives in CSS); on desktop the
+  // class is inert. Skip while the full comparison view owns the screen.
+  if (!comparisonViewOpen) {
+    document.body.classList.add('sheet-open');
   }
 }
 
@@ -146,6 +147,8 @@ function clearPanel(): void {
   const fallback = document.getElementById('no-selection-message');
   if (fallback) fallback.hidden = false;
   document.getElementById('panel-content')!.style.display = 'none';
+  // Slide the mobile bottom sheet back down (inert on desktop).
+  document.body.classList.remove('sheet-open');
   clearHighlight();
   updateCompareButton();
   updateCiteButton();
@@ -165,6 +168,19 @@ export function initPanel(): void {
   if (closeBtn) {
     closeBtn.addEventListener('click', () => setState({ selectedCountry: null }));
   }
+
+  // The mobile bottom sheet's grab handle also dismisses the sheet.
+  const grabber = document.getElementById('sheet-grabber');
+  if (grabber) {
+    grabber.addEventListener('click', () => setState({ selectedCountry: null }));
+  }
+
+  // The scatter explorer takes over the map slot; drop the sheet out of
+  // the way when it opens so it doesn't sit on top of the plot. Tapping a
+  // dot re-selects a country, which re-opens the sheet over the scatter.
+  on('scatterOpen', (open) => {
+    if (open) document.body.classList.remove('sheet-open');
+  });
 
   // Copy the full source list as a numbered, paste-ready block —
   // analysts move these into footnotes and research notes.

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -22,6 +22,85 @@ function normalizeConfidence(raw: string | null | undefined): ConfidenceLevel | 
   return null;
 }
 
+// The bottom-sheet layout is active exactly when this media list matches
+// (phone width OR a short touch viewport / landscape phone) — mirrors the
+// CSS in _responsive.css.
+function isSheetLayout(): boolean {
+  return typeof window.matchMedia === 'function'
+    && window.matchMedia('(max-width: 768px), (max-height: 500px) and (pointer: coarse)').matches;
+}
+
+// Element focused before the sheet took over, so focus can be handed back.
+let sheetOpener: HTMLElement | null = null;
+
+// Give the open sheet dialog semantics and move focus into it (mobile
+// only). Non-modal — the map stays visible and tappable behind the peek,
+// so we deliberately don't trap focus or `inert` the background.
+function openSheetDialog(): void {
+  const panel = document.getElementById('country-panel');
+  if (!panel || !isSheetLayout()) return;
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'false');
+  panel.setAttribute('aria-labelledby', 'country-name');
+  sheetOpener = document.activeElement as HTMLElement | null;
+  const name = document.getElementById('country-name');
+  if (name) {
+    name.setAttribute('tabindex', '-1');
+    name.focus({ preventScroll: true });
+  }
+}
+
+function closeSheetDialog(): void {
+  const panel = document.getElementById('country-panel');
+  if (panel) {
+    panel.removeAttribute('role');
+    panel.removeAttribute('aria-modal');
+    panel.removeAttribute('aria-labelledby');
+  }
+  if (sheetOpener && document.contains(sheetOpener) && sheetOpener.offsetParent !== null) {
+    sheetOpener.focus({ preventScroll: true });
+  }
+  sheetOpener = null;
+}
+
+// Drag-down-to-dismiss on the grab handle — the gesture the pill affords.
+// A tap (no travel) closes via the button's click handler; a small drag
+// springs back; a firm downward drag closes.
+function initSheetDrag(): void {
+  const grabber = document.getElementById('sheet-grabber');
+  const panel = document.getElementById('country-panel');
+  if (!grabber || !panel) return;
+  let startY = 0;
+  let dy = 0;
+  let dragging = false;
+
+  grabber.addEventListener('pointerdown', (e: PointerEvent) => {
+    if (!isSheetLayout()) return;
+    dragging = true;
+    startY = e.clientY;
+    dy = 0;
+    panel.style.transition = 'none';
+    grabber.setPointerCapture(e.pointerId);
+  });
+  grabber.addEventListener('pointermove', (e: PointerEvent) => {
+    if (!dragging) return;
+    dy = Math.max(0, e.clientY - startY);   // downward only
+    panel.style.transform = `translateY(${dy}px)`;
+  });
+  const end = () => {
+    if (!dragging) return;
+    dragging = false;
+    panel.style.transition = '';
+    panel.style.transform = '';
+    // Suppress the click that follows a real drag so it doesn't
+    // double-fire; only a firm downward drag dismisses.
+    if (dy > 6) grabber.dataset.dragged = '1';
+    if (dy > panel.offsetHeight * 0.3) setState({ selectedCountry: null });
+  };
+  grabber.addEventListener('pointerup', end);
+  grabber.addEventListener('pointercancel', end);
+}
+
 function updateDimensionHighlight(): void {
   const { currentAttribute } = getState();
   document.querySelectorAll<HTMLElement>('.dimension-row[data-dimension]').forEach(row => {
@@ -145,7 +224,12 @@ function renderPanel(countryName: string): void {
     // runs on a selection change, so this never clobbers a deliberate
     // scroll mid-read.
     document.getElementById('country-panel')?.scrollTo({ top: 0 });
+    const wasOpen = document.body.classList.contains('sheet-open');
     document.body.classList.add('sheet-open');
+    // Only take over focus on the initial open, not when switching
+    // countries with the sheet already up (that would steal focus on
+    // every tap).
+    if (!wasOpen) openSheetDialog();
   }
 }
 
@@ -155,6 +239,7 @@ function clearPanel(): void {
   document.getElementById('panel-content')!.style.display = 'none';
   // Slide the mobile bottom sheet back down (inert on desktop).
   document.body.classList.remove('sheet-open');
+  closeSheetDialog();
   clearHighlight();
   updateCompareButton();
   updateCiteButton();
@@ -175,11 +260,17 @@ export function initPanel(): void {
     closeBtn.addEventListener('click', () => setState({ selectedCountry: null }));
   }
 
-  // The mobile bottom sheet's grab handle also dismisses the sheet.
+  // The mobile bottom sheet's grab handle: tap (or keyboard) dismisses;
+  // drag-down dismisses via initSheetDrag(). The dataset flag guards the
+  // synthetic click that follows a real drag.
   const grabber = document.getElementById('sheet-grabber');
   if (grabber) {
-    grabber.addEventListener('click', () => setState({ selectedCountry: null }));
+    grabber.addEventListener('click', () => {
+      if (grabber.dataset.dragged) { delete grabber.dataset.dragged; return; }
+      setState({ selectedCountry: null });
+    });
   }
+  initSheetDrag();
 
   // The scatter explorer takes over the map slot; drop the sheet out of
   // the way when it opens so it doesn't sit on top of the plot. Tapping a

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -139,6 +139,12 @@ function renderPanel(countryName: string): void {
   // a country slides it up (the transition lives in CSS); on desktop the
   // class is inert. Skip while the full comparison view owns the screen.
   if (!comparisonViewOpen) {
+    // Reset to the top for every fresh country — otherwise, after
+    // scrolling one country's sheet/panel, the next selection opens
+    // mid-content with the name and score off-screen. renderPanel only
+    // runs on a selection change, so this never clobbers a deliberate
+    // scroll mid-read.
+    document.getElementById('country-panel')?.scrollTo({ top: 0 });
     document.body.classList.add('sheet-open');
   }
 }

--- a/src/panel/scores.ts
+++ b/src/panel/scores.ts
@@ -1,6 +1,12 @@
 import type { ScoreEntry } from '../data/loader';
+import { makeColorScale } from '../map/legend';
+import { cssVar } from '../map/cssColors';
 
-export function renderDots(elId: string, score: number | null): void {
+// Optional colouriser: maps a score to the fill colour for its dots. When
+// omitted the dots fall back to the accent (CSS default).
+type ColorFor = (score: number) => string;
+
+export function renderDots(elId: string, score: number | null, colorFor?: ColorFor): void {
   const el = document.getElementById(elId);
   if (!el) return;
   el.replaceChildren();
@@ -10,6 +16,7 @@ export function renderDots(elId: string, score: number | null): void {
   const s = score ?? 0;
   const whole = Math.floor(s);
   const frac = s - whole;
+  const color = (score != null && colorFor) ? colorFor(score) : null;
   for (let i = 1; i <= 5; i++) {
     const dot = document.createElement('span');
     if (i <= whole) {
@@ -19,6 +26,9 @@ export function renderDots(elId: string, score: number | null): void {
       dot.style.setProperty('--fill', `${Math.round(frac * 100)}%`);
     } else {
       dot.className = 'dim-dot';
+    }
+    if (color && (i <= whole || (i === whole + 1 && frac > 0))) {
+      dot.style.setProperty('--dot-color', color);
     }
     el.appendChild(dot);
   }
@@ -33,14 +43,24 @@ export function renderDots(elId: string, score: number | null): void {
 
 export function renderScoreBar(avg: number | null): void {
   document.getElementById('average-score')!.textContent = avg != null ? `${avg} / 5` : 'N/A';
-  document.getElementById('overall-bar-fill')!.style.width =
-    avg != null ? `${((avg - 1) / 4) * 100}%` : '0%';
+  const fill = document.getElementById('overall-bar-fill')!;
+  fill.style.width = avg != null ? `${((avg - 1) / 4) * 100}%` : '0%';
+  // Colour the fill by where the score lands on the ramp, so it reads the
+  // same as the country on the map — instead of the old gradient that
+  // always ended in "high/blue" no matter the score.
+  fill.style.setProperty('--fill-color', avg != null ? makeColorScale()(avg) : 'transparent');
 }
 
 export function renderAllDots(scoreData: ScoreEntry | null | undefined): void {
-  renderDots('dots-regulation', scoreData ? scoreData.regulationStatus : null);
-  renderDots('dots-policy',     scoreData ? scoreData.policyLever : null);
-  renderDots('dots-governance', scoreData ? scoreData.governanceType : null);
-  renderDots('dots-actors',     scoreData ? scoreData.actorInvolvement : null);
-  renderDots('dots-enforcement', scoreData ? scoreData.enforcementLevel : null);
+  const scale = makeColorScale();
+  // Normative dimensions carry the same red→blue quality language as the
+  // map; the two descriptive dimensions (governance, actor) are NOT a
+  // quality scale, so they stay a neutral tone rather than borrow it.
+  const quality: ColorFor = (v) => scale(v);
+  const neutral: ColorFor = () => cssVar('--text-tertiary');
+  renderDots('dots-regulation', scoreData ? scoreData.regulationStatus : null, quality);
+  renderDots('dots-policy',     scoreData ? scoreData.policyLever : null, quality);
+  renderDots('dots-governance', scoreData ? scoreData.governanceType : null, neutral);
+  renderDots('dots-actors',     scoreData ? scoreData.actorInvolvement : null, neutral);
+  renderDots('dots-enforcement', scoreData ? scoreData.enforcementLevel : null, quality);
 }

--- a/src/scatter/index.ts
+++ b/src/scatter/index.ts
@@ -24,11 +24,25 @@ import { cssVar, onThemeChange } from '../map/cssColors';
 import { createTooltip, showTooltip, hideTooltip } from '../map/tooltip';
 import { jitterFor } from './jitter';
 
-const WIDTH = 760;
-const HEIGHT = 540;
+// The viewBox tracks the container's real pixel box (see layout()) so the
+// plot fills the tall portrait slot instead of letterboxing into a small
+// centered rectangle. These are the fallback/last-measured dimensions.
+let WIDTH = 760;
+let HEIGHT = 540;
 const MARGIN = { top: 24, right: 28, bottom: 52, left: 52 };
 
 const AXIS_DIMENSIONS = SCORE_OPTIONS.filter(o => o.value !== 'averageScore');
+
+function isCoarse(): boolean {
+  return typeof window.matchMedia === 'function'
+    && window.matchMedia('(pointer: coarse)').matches;
+}
+
+// Touch has no hover to identify a dot, and dots overlap in dense score
+// clusters, so a single tap could open the wrong country. On coarse
+// pointers the first tap "previews" a dot (pins its name); a second tap
+// on the same dot commits the selection.
+let previewedName: string | null = null;
 
 /** One country positioned on the two chosen score dimensions. */
 interface ScatterDot {
@@ -65,40 +79,68 @@ function populateAxisSelects(): void {
 function createChart(): void {
   const chart = select('#scatter-chart');
   svg = chart.append<SVGSVGElement>('svg')
-    .attr('viewBox', `0 0 ${WIDTH} ${HEIGHT}`)
     .attr('preserveAspectRatio', 'xMidYMid meet')
     .attr('role', 'img')
     .attr('aria-label', 'Scatter plot of countries across two score dimensions');
 
-  xScale = scaleLinear().domain([0.5, 5.5]).range([MARGIN.left, WIDTH - MARGIN.right]);
-  yScale = scaleLinear().domain([0.5, 5.5]).range([HEIGHT - MARGIN.bottom, MARGIN.top]);
+  xScale = scaleLinear().domain([0.5, 5.5]);
+  yScale = scaleLinear().domain([0.5, 5.5]);
 
   // Axes inherit currentColor from CSS so theme switches restyle them
   // for free; only the dot fills need explicit recoloring.
-  svg.append('g')
-    .attr('class', 'scatter-axis scatter-axis-x')
-    .attr('transform', `translate(0,${HEIGHT - MARGIN.bottom})`)
-    .call(axisBottom(xScale).tickValues([1, 2, 3, 4, 5]).tickFormat(format('d')));
-
-  svg.append('g')
-    .attr('class', 'scatter-axis scatter-axis-y')
-    .attr('transform', `translate(${MARGIN.left},0)`)
-    .call(axisLeft(yScale).tickValues([1, 2, 3, 4, 5]).tickFormat(format('d')));
+  svg.append('g').attr('class', 'scatter-axis scatter-axis-x');
+  svg.append('g').attr('class', 'scatter-axis scatter-axis-y');
 
   svg.append('text')
     .attr('class', 'scatter-axis-label')
     .attr('id', 'scatter-x-label')
-    .attr('x', MARGIN.left + (WIDTH - MARGIN.left - MARGIN.right) / 2)
-    .attr('y', HEIGHT - 8)
     .attr('text-anchor', 'middle');
 
   svg.append('text')
     .attr('class', 'scatter-axis-label')
     .attr('id', 'scatter-y-label')
     .attr('transform', 'rotate(-90)')
-    .attr('x', -(MARGIN.top + (HEIGHT - MARGIN.top - MARGIN.bottom) / 2))
-    .attr('y', 13)
     .attr('text-anchor', 'middle');
+
+  layout();
+
+  // Re-fit whenever the chart box changes size — the container settles
+  // after open, the menu collapsing lengthens it, and rotation resizes
+  // it. A ResizeObserver catches all of these (a one-time measure and a
+  // window-resize listener both miss the header-height changes).
+  if (typeof ResizeObserver === 'function') {
+    const ro = new ResizeObserver(() => {
+      if (getState().scatterOpen) { layout(); updateChart(); }
+    });
+    ro.observe(document.getElementById('scatter-chart')!);
+  }
+}
+
+// Fit the chart to the container's actual box and (re)position the axes
+// and labels. Called on creation and on resize/orientation change so a
+// rotated phone re-lays-out instead of staying letterboxed.
+function layout(): void {
+  if (!svg) return;
+  const box = document.getElementById('scatter-chart');
+  WIDTH = Math.max(280, box?.clientWidth || WIDTH);
+  HEIGHT = Math.max(240, box?.clientHeight || HEIGHT);
+  svg.attr('viewBox', `0 0 ${WIDTH} ${HEIGHT}`);
+  xScale.range([MARGIN.left, WIDTH - MARGIN.right]);
+  yScale.range([HEIGHT - MARGIN.bottom, MARGIN.top]);
+
+  svg.select<SVGGElement>('.scatter-axis-x')
+    .attr('transform', `translate(0,${HEIGHT - MARGIN.bottom})`)
+    .call(axisBottom(xScale).tickValues([1, 2, 3, 4, 5]).tickFormat(format('d')));
+  svg.select<SVGGElement>('.scatter-axis-y')
+    .attr('transform', `translate(${MARGIN.left},0)`)
+    .call(axisLeft(yScale).tickValues([1, 2, 3, 4, 5]).tickFormat(format('d')));
+
+  svg.select('#scatter-x-label')
+    .attr('x', MARGIN.left + (WIDTH - MARGIN.left - MARGIN.right) / 2)
+    .attr('y', HEIGHT - 8);
+  svg.select('#scatter-y-label')
+    .attr('x', -(MARGIN.top + (HEIGHT - MARGIN.top - MARGIN.bottom) / 2))
+    .attr('y', 13);
 }
 
 function dotTooltipHtml(d: PlottedDot, xKey: AttributeKey, yKey: AttributeKey): string {
@@ -140,6 +182,10 @@ function updateChart(): void {
   const colorScale = makeColorScale();
   const noData = cssVar('--no-data');
   const strokeColor = cssVar('--surface');
+  const coarse = isCoarse();
+  const baseR = coarse ? 6 : 4.5;      // easier to hit on touch
+  const bigR = coarse ? 9.5 : 7;       // selected / previewed
+  const isMarked = (name: string) => name === selectedCountry || name === previewedName;
 
   svg.selectAll<SVGCircleElement, PlottedDot>('circle.scatter-dot')
     .data(countries, d => d.name)
@@ -148,7 +194,7 @@ function updateChart(): void {
         .attr('class', 'scatter-dot')
         .attr('cx', d => xScale(d.x + jitterFor(d.name).dx))
         .attr('cy', d => yScale(d.y + jitterFor(d.name).dy))
-        .on('click', (e, d) => setState({ selectedCountry: d.name }))
+        .on('click', (e, d) => onDotClick(d.name))
         .on('mouseenter', (e, d) => showTooltip(e, dotTooltipHtml(d, getState().scatterX, getState().scatterY)))
         .on('mouseleave', hideTooltip),
       update => update,
@@ -157,24 +203,37 @@ function updateChart(): void {
     .transition().duration(300)
     .attr('cx', d => xScale(d.x + jitterFor(d.name).dx))
     .attr('cy', d => yScale(d.y + jitterFor(d.name).dy))
-    .attr('r', d => d.name === selectedCountry ? 7 : 4.5)
+    .attr('r', d => isMarked(d.name) ? bigR : baseR)
     .attr('fill', d => d.avg != null ? colorScale(d.avg) : noData)
     .attr('stroke', strokeColor)
-    .attr('stroke-width', d => d.name === selectedCountry ? 2 : 0.6)
+    .attr('stroke-width', d => isMarked(d.name) ? 2 : 0.6)
     .style('opacity', d => d.visible ? 0.85 : 0.15);
 
-  // Name label pinned to the selected country's dot — in a 196-dot
-  // field the highlight ring alone is easy to lose.
-  const selectedDot = selectedCountry
-    ? countries.find(d => d.name === selectedCountry)
-    : undefined;
+  // Name labels pinned to the selected dot AND (on touch) the previewed
+  // dot — in a 196-dot field the highlight ring alone is easy to lose,
+  // and the preview needs to say which country you're about to open.
+  const labelled = countries.filter(d => isMarked(d.name));
   svg.selectAll<SVGTextElement, PlottedDot>('text.scatter-dot-label')
-    .data(selectedDot ? [selectedDot] : [], d => d.name)
+    .data(labelled, d => d.name)
     .join('text')
     .attr('class', 'scatter-dot-label')
+    .classed('is-preview', d => d.name === previewedName && d.name !== selectedCountry)
     .attr('x', d => xScale(d.x + jitterFor(d.name).dx) + 11)
     .attr('y', d => yScale(d.y + jitterFor(d.name).dy) + 4)
     .text(d => d.name);
+}
+
+// Touch: first tap previews (names) the dot, second tap on the same dot
+// selects it. Mouse (fine pointer): tap selects immediately — hover
+// already reveals identity.
+function onDotClick(name: string): void {
+  if (isCoarse() && previewedName !== name) {
+    previewedName = name;
+    updateChart();
+  } else {
+    previewedName = null;
+    setState({ selectedCountry: name });
+  }
 }
 
 function setVisible(open: boolean): void {
@@ -188,9 +247,14 @@ function setVisible(open: boolean): void {
   btn.classList.toggle('active', open);
   btn.setAttribute('aria-pressed', String(open));
   if (open) {
+    previewedName = null;
     if (!svg) {
       createTooltip();
       createChart();
+    } else {
+      // Re-measure: the container may have resized (or the phone rotated)
+      // while the explorer was closed.
+      layout();
     }
     updateChart();
   }
@@ -232,7 +296,8 @@ export function initScatter(): void {
     sel.value = getState().scatterY;
     refreshIfOpen();
   });
-  on('selectedCountry', refreshIfOpen);
+  // A selection made elsewhere (search, keyboard) clears a stale preview.
+  on('selectedCountry', () => { previewedName = null; refreshIfOpen(); });
   on('currentAttribute', refreshIfOpen);
   on('filterMin', refreshIfOpen);
   on('filterMax', refreshIfOpen);

--- a/src/styles/_blocs.css
+++ b/src/styles/_blocs.css
@@ -182,7 +182,7 @@
   text-decoration: underline;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 768px), (max-height: 500px) and (pointer: coarse) {
   .bloc-summary {
     top: 10px;
     left: 10px;

--- a/src/styles/_blocs.css
+++ b/src/styles/_blocs.css
@@ -190,5 +190,11 @@
     width: auto;
     max-width: 280px;
     padding: 10px 12px;
+    /* The card sits over the very region it summarizes; a translucent,
+       blurred surface lets the highlighted members read through it
+       without sacrificing the stats' legibility. */
+    background: color-mix(in oklch, var(--surface) 85%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
   }
 }

--- a/src/styles/_blocs.css
+++ b/src/styles/_blocs.css
@@ -10,7 +10,8 @@
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  padding: 6px 8px;
+  height: var(--control-h);
+  padding: 0 8px;
   font-size: 0.78rem;
   font-family: 'Geist', -apple-system, sans-serif;
   color: var(--text-primary);

--- a/src/styles/_comparison.css
+++ b/src/styles/_comparison.css
@@ -494,7 +494,7 @@ body.view-compare .radar-chart svg {
 .country.in-comparison[data-comparison-index="2"] { stroke: var(--comparison-3); }
 .country.in-comparison[data-comparison-index="3"] { stroke: var(--comparison-4); }
 
-@media (max-width: 768px) {
+@media (max-width: 768px), (max-height: 500px) and (pointer: coarse) {
   #comparison-panel {
     width: 100%;
     min-width: 0;

--- a/src/styles/_comparison.css
+++ b/src/styles/_comparison.css
@@ -499,6 +499,7 @@ body.view-compare .radar-chart svg {
     width: 100%;
     min-width: 0;
     max-height: 70vh;
+    max-height: 70dvh;
     border-left: none;
     border-top: 1px solid var(--border);
   }

--- a/src/styles/_comparison.css
+++ b/src/styles/_comparison.css
@@ -550,11 +550,11 @@ body.view-compare .radar-chart svg {
 }
 
 @media (pointer: coarse) {
-  .comp-chip-remove { width: 36px; height: 36px; }
+  .comp-chip-remove { width: 40px; height: 40px; }
   .clear-comparison-btn,
   .compare-btn,
   .comp-add-btn {
-    min-height: 40px;
+    min-height: 44px;
     padding-top: 9px;
     padding-bottom: 9px;
   }

--- a/src/styles/_comparison.css
+++ b/src/styles/_comparison.css
@@ -547,6 +547,21 @@ body.view-compare .radar-chart svg {
   .comparison-table td {
     padding: 12px 12px 12px 0;
   }
+
+  /* Pin the dimension-name column while the 3-4 country table scrolls
+     sideways, so a value's row label doesn't scroll out of view. */
+  .ct-label {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    background: var(--surface);
+  }
+
+  /* The radar's axis labels are ~10 units in a downscaled viewBox — ~7px
+     on a phone. Bump them so the dimension names are legible. */
+  .radar-axis-label {
+    font-size: 14px;
+  }
 }
 
 @media (pointer: coarse) {
@@ -610,6 +625,17 @@ body.view-compare .radar-chart svg {
   align-items: center;
   gap: 6px;
   margin-bottom: 12px;
+}
+
+.strip-add {
+  margin-bottom: 12px;
+}
+
+/* The strip sits at the bottom of the sheet, so its add-a-country dropdown
+   opens upward to stay on-screen. */
+#tray-add .comp-search-suggestions {
+  top: auto;
+  bottom: calc(100% + 6px);
 }
 
 .strip-view-btn {

--- a/src/styles/_comparison.css
+++ b/src/styles/_comparison.css
@@ -504,6 +504,27 @@ body.view-compare .radar-chart svg {
     border-top: 1px solid var(--border);
   }
 
+  /* Full comparison view: let the PAGE own the scroll. Without this the
+     panel keeps its 70vh cap, so the whole score/description table — the
+     actual point of Compare — sits below an unmarked internal-scroll fold
+     while the footer paints right under the radar and reads as
+     "end of page". Grow the panel to its content and let #app-main
+     (normally overflow:hidden for the sheet) grow with it. */
+  body.view-compare #app-main {
+    overflow: visible;
+  }
+
+  body.view-compare #comparison-panel {
+    max-height: none;
+    overflow: visible;
+    flex: none;
+  }
+
+  /* Cap the radar so the numbers aren't pushed a full screen down. */
+  body.view-compare .radar-chart svg {
+    max-width: 300px;
+  }
+
   .comp-chip {
     padding: 6px 10px 6px 12px;
   }

--- a/src/styles/_header.css
+++ b/src/styles/_header.css
@@ -133,6 +133,14 @@ h1 {
   animation: fadeUp 0.2s var(--ease-out);
 }
 
+/* The list is emptied (not detached) when there are no matches; without
+   this it collapses to a thin bordered strip floating under the search.
+   Most visible on mobile where the input — and so the strip — is full
+   width. */
+#search-suggestions:empty {
+  display: none;
+}
+
 #search-suggestions li {
   padding: 9px 14px;
   cursor: pointer;

--- a/src/styles/_header.css
+++ b/src/styles/_header.css
@@ -142,6 +142,22 @@ h1 {
   display: none;
 }
 
+/* Explicit "no matches" row so a fruitless search reads as answered,
+   not broken (the box no longer just disappears). Non-interactive. */
+#search-suggestions li.search-empty {
+  padding: 12px 14px;
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+  font-style: italic;
+  cursor: default;
+  border-bottom: none;
+}
+
+#search-suggestions li.search-empty:hover {
+  background: none;
+  color: var(--text-tertiary);
+}
+
 #search-suggestions li {
   padding: 9px 14px;
   cursor: pointer;

--- a/src/styles/_header.css
+++ b/src/styles/_header.css
@@ -98,7 +98,8 @@ h1 {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  padding: 7px 12px;
+  height: var(--control-h);
+  padding: 0 12px;
   font-size: 0.8rem;
   font-family: 'Geist', -apple-system, sans-serif;
   color: var(--text-primary);
@@ -228,7 +229,8 @@ h1 {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  padding: 7px 12px;
+  height: var(--control-h);
+  padding: 0 12px;
   font-size: 0.8rem;
   font-family: 'Geist', -apple-system, sans-serif;
   color: var(--text-secondary);
@@ -468,8 +470,8 @@ input[type="range"] {
   background: transparent;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  width: 34px;
-  height: 34px;
+  width: var(--control-h);
+  height: var(--control-h);
   padding: 0;
   cursor: pointer;
   color: var(--text-secondary);
@@ -495,3 +497,41 @@ input[type="range"] {
 .theme-toggle .theme-icon-moon { display: none; }
 .theme-toggle[data-theme='light'] .theme-icon-sun { display: none; }
 .theme-toggle[data-theme='light'] .theme-icon-moon { display: block; }
+
+/* Menu (☰) toggle — only appears on mobile (see _responsive.css), where
+   it folds the secondary controls away so the map keeps the screen.
+   Hidden on desktop, which shows the full toolbar inline. */
+.menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: var(--control-h);
+  height: var(--control-h);
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.18s var(--ease-out), border-color 0.18s var(--ease-out), background 0.18s var(--ease-out);
+}
+
+.menu-toggle:hover,
+.menu-toggle[aria-expanded='true'] {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-muted);
+}
+
+.menu-icon {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+
+/* On desktop the metadata just flows inline in the header; the wrapper
+   is only a layout handle for the mobile menu. */
+.header-meta {
+  display: contents;
+}

--- a/src/styles/_header.css
+++ b/src/styles/_header.css
@@ -103,7 +103,7 @@ h1 {
   font-size: 0.8rem;
   font-family: 'Geist', -apple-system, sans-serif;
   color: var(--text-primary);
-  width: 170px;
+  width: 200px;
   transition: border-color 0.2s var(--ease-out), width 0.3s var(--ease-out), box-shadow 0.2s var(--ease-out);
 }
 
@@ -114,7 +114,7 @@ h1 {
 
 #country-search:focus {
   border-color: var(--accent);
-  width: 220px;
+  width: 250px;
   box-shadow: 0 0 0 3px var(--accent-muted);
 }
 

--- a/src/styles/_map.css
+++ b/src/styles/_map.css
@@ -72,6 +72,58 @@
   background: var(--accent-muted);
 }
 
+/* First-run hint for touch users — the desktop intro panel lives in the
+   sheet, off-screen until a country is selected (the one thing it teaches).
+   Shown by src/controls/onboarding.ts only on the sheet layout and only
+   once; retired on the first selection. */
+.mobile-hint {
+  position: absolute;
+  top: 10px;
+  left: 12px;
+  right: 12px;
+  z-index: 12;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 8px 9px 14px;
+  background: color-mix(in oklch, var(--surface-raised) 92%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.14);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  animation: fadeUp 0.3s var(--ease-out);
+}
+
+.mobile-hint[hidden] {
+  display: none;
+}
+
+.mobile-hint span {
+  flex: 1;
+}
+
+.mobile-hint a {
+  color: var(--accent);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.mobile-hint-close {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+  flex-shrink: 0;
+}
+
 /* Tooltip */
 .tooltip {
   position: absolute;

--- a/src/styles/_panel.css
+++ b/src/styles/_panel.css
@@ -603,6 +603,12 @@
   margin-top: 4px;
 }
 
+/* Grab handle for the mobile bottom sheet — hidden on desktop, where
+   the panel is a fixed side column. Styled + revealed in _responsive.css. */
+.sheet-grabber {
+  display: none;
+}
+
 /* Panel close — touch-equivalent of Esc; desktop keeps keyboard/click-away */
 .panel-close {
   display: none;

--- a/src/styles/_panel.css
+++ b/src/styles/_panel.css
@@ -177,9 +177,11 @@
 
 .score-bar-fill {
   height: 100%;
-  /* Same low→high ramp as the choropleth so a given score reads the
-     same color here as it does on the map. */
-  background: linear-gradient(90deg, var(--score-low), var(--score-high));
+  /* Solid fill coloured by the score's position on the choropleth ramp
+     (set in renderScoreBar), so a given value reads the same colour here
+     as the country does on the map — the old gradient always ended in
+     "high/blue" regardless of the score. */
+  background: var(--fill-color, var(--score-high));
   border-radius: 2px;
   transition: width 0.5s var(--ease-out);
   width: 0%;
@@ -193,7 +195,7 @@
   top: -1px;
   width: 6px;
   height: 6px;
-  background: var(--score-high);
+  background: var(--fill-color, var(--score-high));
   border-radius: 50%;
 }
 
@@ -327,13 +329,13 @@
 }
 
 .dim-dot.filled {
-  background: var(--accent);
+  background: var(--dot-color, var(--accent));
 }
 
 /* Fractional dot — the quarter-point part of a v2 score, filled
    left-to-right so a 1.75 reads as one full dot plus a three-quarter dot. */
 .dim-dot.partial {
-  background: linear-gradient(90deg, var(--accent) var(--fill, 50%), var(--border) var(--fill, 50%));
+  background: linear-gradient(90deg, var(--dot-color, var(--accent)) var(--fill, 50%), var(--border) var(--fill, 50%));
 }
 
 /* Confidence badge — always visible at high/medium/low, but visual
@@ -365,8 +367,9 @@
 }
 
 .confidence-badge[data-level='high'] {
-  /* Understated — "nothing to see" for high-confidence records. */
-  opacity: 0.65;
+  /* Understated, but still legible — this is the "trust me" signal, so a
+     0.65 opacity on tertiary text was too faint to actually read. */
+  color: var(--text-secondary);
 }
 
 .confidence-badge[data-level='medium'] {
@@ -382,6 +385,28 @@
   color: oklch(64% 0.19 28);
   background: oklch(64% 0.19 28 / 0.12);
   border-color: oklch(64% 0.19 28 / 0.30);
+}
+
+/* The mid/high-lightness hues above are tuned for the dark surface; on the
+   cream light theme they don't clear AA at this small size. Darken the
+   text (keep the tint fill) so the caveat stays readable where it matters
+   most — the citation-friendly daylight default. */
+:root[data-theme='light'] .confidence-badge[data-level='medium'] {
+  color: oklch(52% 0.14 62);
+}
+
+:root[data-theme='light'] .confidence-badge[data-level='low'] {
+  color: oklch(48% 0.19 28);
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) .confidence-badge[data-level='medium'] {
+    color: oklch(52% 0.14 62);
+  }
+
+  :root:not([data-theme]) .confidence-badge[data-level='low'] {
+    color: oklch(48% 0.19 28);
+  }
 }
 
 /* Panel header actions row — Compare + Cite sit side by side. */

--- a/src/styles/_reset.css
+++ b/src/styles/_reset.css
@@ -10,10 +10,17 @@ body {
   color: var(--text-primary);
   display: flex;
   flex-direction: column;
+  /* dvh follows the visible viewport as mobile browser chrome slides
+     in/out, so the footer never hides behind the URL bar. vh is the
+     fallback for engines without dvh. */
   min-height: 100vh;
+  min-height: 100dvh;
   font-size: 14px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  /* Drop the grey/blue flash iOS and Android paint over tapped
+     elements — selection/active states already give feedback. */
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* Subtle grain texture — dark theme only. On light theme the grain

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -14,28 +14,80 @@
 }
 
 @media (max-width: 768px) {
+  /* The map fills this whole area now; the detail panel is a sheet
+     layered on top (below) rather than a second row. position:relative
+     anchors that sheet to the map area, and overflow:hidden clips it
+     while it's parked off the bottom edge. */
   #app-main {
     flex-direction: column;
-    overflow: auto;
+    position: relative;
+    overflow: hidden;
   }
 
-  /* dvh tracks the visible viewport as the mobile URL bar shows/hides,
-     so the map doesn't jump or get clipped the way vh does. vh stays
-     as the fallback for engines without dvh. */
   #map-wrapper {
-    min-height: 50vh;
-    min-height: 50dvh;
+    min-height: 0;
   }
 
-  /* Once a country is open, the prose is what you're reading on a
-     phone — give the panel a little more room than the map. It still
-     scrolls internally past this cap. */
+  /* Country detail as a bottom sheet. It slides up over the map when a
+     country is selected and back down on close, instead of pushing the
+     map into a shared scroll. Anchored to #app-main (not the viewport)
+     so it never collides with the header or the timeline/footer. */
   #country-panel {
-    width: 100%;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: auto;
+    height: 88%;
+    max-height: none;
     border-left: none;
     border-top: 1px solid var(--border);
-    max-height: 50vh;
-    max-height: 60dvh;
+    border-radius: 18px 18px 0 0;
+    box-shadow: 0 -14px 44px -16px rgba(0, 0, 0, 0.45);
+    transform: translateY(100%);
+    transition: transform 0.34s var(--ease-out);
+    z-index: 400;
+  }
+
+  body.sheet-open #country-panel {
+    transform: translateY(0);
+  }
+
+  /* Sticky grab handle: a familiar "swipe / tap to dismiss" affordance
+     that stays put while the sheet scrolls, so closing is always one
+     tap away. The wide invisible ::after is the real touch target. */
+  .sheet-grabber {
+    display: block;
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    height: 22px;
+    background: var(--surface);
+    border-radius: 18px 18px 0 0;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .sheet-grabber::before {
+    content: '';
+    position: absolute;
+    top: 9px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 36px;
+    height: 4px;
+    border-radius: 999px;
+    background: var(--border);
+  }
+
+  .sheet-grabber::after {
+    content: '';
+    position: absolute;
+    top: -6px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 96px;
+    height: 34px;
   }
 
   #timeline-inner {
@@ -52,16 +104,16 @@
     padding: 16px 18px;
   }
 
-  /* Header reflows on mobile. The brand line (title + last-updated +
-     badge) gets row 1. The search input gets row 2 (full-width so
-     users can type comfortably). Score + filter + theme toggle share
-     row 3, left-aligned. This keeps the freshness signal visible and
-     avoids the old right-edge overflow. */
+  /* Header reflows on mobile into calm rows instead of a cramped
+     cluster: the brand line up top, then the search paired with the
+     theme toggle, then the four view controls on their own roomy row.
+     Ordering is done with `order` (not DOM changes) so the popovers keep
+     anchoring to their buttons. */
   #app-header {
     flex-wrap: wrap;
     height: auto;
-    padding: 10px 12px;
-    gap: 8px 10px;
+    padding: 12px 14px;
+    gap: 10px;
   }
 
   .header-left {
@@ -71,41 +123,67 @@
   }
 
   .header-right {
-    gap: 6px;
+    gap: 10px;
     flex-wrap: wrap;
     width: 100%;
+    align-items: center;
     justify-content: flex-start;
   }
 
+  /* Row: search grows to fill, theme toggle rides along at the end so
+     it isn't wedged into the button group. */
   #search-container {
-    width: 100%;
-    flex: 1 1 100%;
+    order: 1;
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto;
   }
 
-  #country-search {
-    width: 100%;
-  }
-
+  #country-search,
   #country-search:focus {
     width: 100%;
+  }
+
+  .theme-toggle {
+    order: 2;
+  }
+
+  /* Row: the four view controls, evenly spaced with room to breathe. */
+  #score-btn-container,
+  #filter-btn-container,
+  #scatter-btn,
+  #export-btn-container {
+    order: 3;
+  }
+
+  #score-btn,
+  #filter-btn,
+  #export-btn,
+  #scatter-btn {
+    padding: 9px 14px;
   }
 
   h1 {
     font-size: 1.05rem;
   }
 
-  /* On mobile the score and filter buttons sit on the LEFT side of
-     the row, so the popovers need to open to the right of their
-     trigger, not the left. Otherwise they clip off-screen. */
-  #score-dropdown,
-  #filter-popover {
-    left: 0;
-    right: auto;
+  /* Anchor the toolbar popovers to the header itself rather than each
+     button, so they can't run off the right edge wherever a button
+     lands in the reflowed rows. They drop in as tidy full-width panels
+     just below the toolbar. */
+  #score-btn-container,
+  #filter-btn-container,
+  #export-btn-container {
+    position: static;
   }
 
+  #score-dropdown,
+  #filter-popover,
   #export-popover {
-    left: auto;
-    right: 0;
+    left: 14px;
+    right: 14px;
+    width: auto;
+    min-width: 0;
   }
 }
 

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -205,19 +205,24 @@
     justify-content: space-between;
   }
 
-  /* Secondary controls collapse behind the menu button. */
+  /* The theme toggle stays out on the search row — light/dark is the most
+     re-toggled control and the brand mandates a persistent toggle, so it
+     must not hide behind the menu. */
+  .theme-toggle {
+    order: 1;
+  }
+
+  /* Only the genuinely-secondary view controls collapse behind ☰. The
+     freshness metadata (a trust signal for this audience) stays visible. */
   #filter-btn-container,
   #scatter-btn,
-  #export-btn-container,
-  .theme-toggle {
+  #export-btn-container {
     order: 3;
   }
 
-  body:not(.controls-open) .header-meta,
   body:not(.controls-open) #filter-btn-container,
   body:not(.controls-open) #scatter-btn,
-  body:not(.controls-open) #export-btn-container,
-  body:not(.controls-open) .theme-toggle {
+  body:not(.controls-open) #export-btn-container {
     display: none;
   }
 

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -116,8 +116,10 @@
     gap: 10px;
   }
 
+  /* Bigger than desktop, not smaller: the wordmark is the brand anchor
+     and needs to hold its own against the 44px touch controls. */
   h1 {
-    font-size: 1.05rem;
+    font-size: 1.3rem;
   }
 
   .header-left {
@@ -166,8 +168,17 @@
     width: 100%;
   }
 
+  /* The score selector spans the row on its own line — it reads as a
+     deliberate "you are viewing …" control instead of a small button
+     stranded in empty space. Caret parks at the right like a select. */
   #score-btn-container {
     order: 2;
+    flex: 1 1 100%;
+  }
+
+  #score-btn {
+    width: 100%;
+    justify-content: space-between;
   }
 
   /* Secondary controls collapse behind the menu button. */

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -49,7 +49,10 @@
     border-left: none;
     border-top: 1px solid var(--border);
     border-radius: 18px 18px 0 0;
-    box-shadow: 0 -14px 44px -16px rgba(0, 0, 0, 0.45);
+    /* The inset top highlight defines the sheet's edge against a dark map
+       (a downward black shadow is invisible there); negligible on light. */
+    box-shadow: 0 -14px 44px -16px rgba(0, 0, 0, 0.45),
+                inset 0 1px 0 rgba(255, 255, 255, 0.07);
     transform: translateY(100%);
     transition: transform 0.34s var(--ease-out);
     z-index: 400;

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -75,6 +75,15 @@
     height: 66%;
   }
 
+  /* The Cite popover opens inline near the top of the sheet; cap it so its
+     APA/Chicago/MLA blocks scroll within the popover instead of shoving
+     the scores off-screen and clipping the last format. */
+  .cite-popover {
+    max-height: 60vh;
+    max-height: 60dvh;
+    overflow-y: auto;
+  }
+
   /* Sticky grab handle: a familiar "swipe / tap to dismiss" affordance
      that stays put while the sheet scrolls, so closing is always one
      tap away. The wide invisible ::after is the real touch target. */
@@ -347,6 +356,15 @@
     min-height: 44px;
     display: flex;
     align-items: center;
+  }
+
+  /* Full-text search hits are readable, not squinty, on a phone. */
+  .match-snippet {
+    font-size: 0.82rem;
+  }
+
+  .match-field {
+    font-size: 0.72rem;
   }
 
   /* Citation + panel controls to the 44px standard. Source chips are the

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -104,11 +104,11 @@
     padding: 16px 18px;
   }
 
-  /* Header reflows on mobile into calm rows instead of a cramped
-     cluster: the brand line up top, then the search paired with the
-     theme toggle, then the four view controls on their own roomy row.
-     Ordering is done with `order` (not DOM changes) so the popovers keep
-     anchoring to their buttons. */
+  /* Mobile header: a compact two-row bar — wordmark + a menu toggle on
+     top, then search paired with the score selector. The secondary
+     controls (filter, scatter, export, theme) and the freshness
+     metadata fold behind the ☰ toggle so the map keeps the screen.
+     Ordering is done with `order`, so popovers keep anchoring cleanly. */
   #app-header {
     flex-wrap: wrap;
     height: auto;
@@ -116,10 +116,32 @@
     gap: 10px;
   }
 
+  h1 {
+    font-size: 1.05rem;
+  }
+
   .header-left {
     flex-wrap: wrap;
+    align-items: center;
     gap: 6px 10px;
     width: 100%;
+  }
+
+  /* The ☰ toggle caps the wordmark row on the right. */
+  #menu-toggle {
+    display: inline-flex;
+    order: 1;
+    margin-left: auto;
+  }
+
+  /* Freshness metadata gets its own line, revealed with the menu — a
+     trust signal, not a permanent fixture eating vertical space. */
+  .header-meta {
+    order: 2;
+    flex-basis: 100%;
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
   }
 
   .header-right {
@@ -130,8 +152,8 @@
     justify-content: flex-start;
   }
 
-  /* Row: search grows to fill, theme toggle rides along at the end so
-     it isn't wedged into the button group. */
+  /* Row 2: search grows; the score selector rides beside it and doubles
+     as the "you are viewing …" label for the map. */
   #search-container {
     order: 1;
     flex: 1 1 auto;
@@ -144,27 +166,31 @@
     width: 100%;
   }
 
-  .theme-toggle {
+  #score-btn-container {
     order: 2;
   }
 
-  /* Row: the four view controls, evenly spaced with room to breathe. */
-  #score-btn-container,
+  /* Secondary controls collapse behind the menu button. */
   #filter-btn-container,
   #scatter-btn,
-  #export-btn-container {
+  #export-btn-container,
+  .theme-toggle {
     order: 3;
+  }
+
+  body:not(.controls-open) .header-meta,
+  body:not(.controls-open) #filter-btn-container,
+  body:not(.controls-open) #scatter-btn,
+  body:not(.controls-open) #export-btn-container,
+  body:not(.controls-open) .theme-toggle {
+    display: none;
   }
 
   #score-btn,
   #filter-btn,
   #export-btn,
   #scatter-btn {
-    padding: 9px 14px;
-  }
-
-  h1 {
-    font-size: 1.05rem;
+    padding: 0 14px;
   }
 
   /* Anchor the toolbar popovers to the header itself rather than each
@@ -188,13 +214,13 @@
 }
 
 /* Coarse pointers (touch devices): guarantee 44px hit targets even
-   when the visual element stays compact. */
+   when the visual element stays compact. The shared control height
+   drives search, buttons and toggles up to 44px in one move. */
 @media (pointer: coarse) {
-  #score-btn,
-  #filter-btn,
-  #export-btn,
-  #scatter-btn,
-  .theme-toggle,
+  :root {
+    --control-h: 44px;
+  }
+
   #timeline-reset,
   #zoom-controls button {
     min-height: 44px;

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -1,7 +1,9 @@
 /* Tablet tier — compact the panel and search without collapsing
    the layout. Covers the gap between mobile (768px) and full
-   desktop (1041px+). */
-@media (max-width: 1040px) and (min-width: 769px) {
+   desktop (1041px+). The min-height guard keeps landscape phones
+   (short + wide) out of this cramped-sidebar tier — they get the
+   mobile sheet instead. */
+@media (max-width: 1040px) and (min-width: 769px) and (min-height: 501px) {
   #country-panel {
     width: 300px;
   }
@@ -13,7 +15,11 @@
   #country-search:focus { width: 180px; }
 }
 
-@media (max-width: 768px) {
+/* The mobile tier also covers landscape phones and other short touch
+   viewports (which are WIDER than 768px and would otherwise fall into the
+   cramped desktop/tablet layout). `pointer: coarse` keeps a short desktop
+   window from being flipped into a phone sheet. */
+@media (max-width: 768px), (max-height: 500px) and (pointer: coarse) {
   /* The map fills this whole area now; the detail panel is a sheet
      layered on top (below) rather than a second row. position:relative
      anchors that sheet to the map area, and overflow:hidden clips it
@@ -280,5 +286,30 @@
 
   .panel-intro-steps li:has(kbd) {
     display: none;
+  }
+}
+
+/* Landscape phones are very short — reclaim vertical space so the map and
+   the open sheet aren't crushed. The mobile tier above already gives
+   these the collapsed header + sheet; this just tightens the fit. */
+@media (orientation: landscape) and (max-height: 500px) and (pointer: coarse) {
+  /* Footer links add nothing while reading and cost ~76px of height. */
+  footer {
+    display: none;
+  }
+
+  #timeline-strip {
+    padding: 6px 12px;
+  }
+
+  /* Pair search with the score selector on one row instead of stacking,
+     so the header eats two rows, not three. */
+  #score-btn-container {
+    flex: 1 1 auto;
+  }
+
+  /* The map slot is tiny here, so let the sheet claim more of it. */
+  #country-panel {
+    height: 94%;
   }
 }

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -19,19 +19,37 @@
     overflow: auto;
   }
 
+  /* dvh tracks the visible viewport as the mobile URL bar shows/hides,
+     so the map doesn't jump or get clipped the way vh does. vh stays
+     as the fallback for engines without dvh. */
   #map-wrapper {
     min-height: 50vh;
+    min-height: 50dvh;
   }
 
+  /* Once a country is open, the prose is what you're reading on a
+     phone — give the panel a little more room than the map. It still
+     scrolls internally past this cap. */
   #country-panel {
     width: 100%;
     border-left: none;
     border-top: 1px solid var(--border);
     max-height: 50vh;
+    max-height: 60dvh;
   }
 
   #timeline-inner {
     max-width: 100%;
+  }
+
+  /* Tighten page gutters so the slider and footer links aren't crammed
+     against the screen edges on narrow phones. */
+  #timeline-strip {
+    padding: 10px 14px;
+  }
+
+  footer {
+    padding: 16px 18px;
   }
 
   /* Header reflows on mobile. The brand line (title + last-updated +
@@ -103,6 +121,24 @@
   #zoom-controls button {
     min-height: 44px;
     min-width: 44px;
+  }
+
+  /* iOS Safari zooms the whole page in when you focus a control whose
+     text is under 16px, then leaves you scrolled awkwardly. Pin every
+     text field and dropdown to 16px on touch so tapping search,
+     compare, or the filters never triggers that jump. */
+  #country-search,
+  .comp-search-input,
+  #bloc-select,
+  .scatter-controls select {
+    font-size: 16px;
+  }
+
+  /* The map owns pan/pinch here; tell the browser not to also read
+     those gestures as page scroll/zoom. Removes the gesture tug-of-war
+     (and the touch-intent delay) when dragging across the map. */
+  #map svg {
+    touch-action: none;
   }
 
   .dimension-row {

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -53,10 +53,19 @@
     transform: translateY(100%);
     transition: transform 0.34s var(--ease-out);
     z-index: 400;
+    /* Keep an over-scroll of the sheet from chaining to the page
+       (accidental pull-to-refresh mid-read). */
+    overscroll-behavior: contain;
   }
 
   body.sheet-open #country-panel {
     transform: translateY(0);
+  }
+
+  /* While reading a country the footer links add nothing and cost ~76px;
+     hiding them lets #app-main (and the sheet) reclaim the height. */
+  body.sheet-open footer {
+    display: none;
   }
 
   /* Sticky grab handle: a familiar "swipe / tap to dismiss" affordance
@@ -67,11 +76,20 @@
     position: sticky;
     top: 0;
     z-index: 5;
+    width: 100%;
     height: 22px;
+    appearance: none;
+    -webkit-appearance: none;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    color: inherit;
     background: var(--surface);
     border-radius: 18px 18px 0 0;
     cursor: pointer;
     flex-shrink: 0;
+    /* Let the pointer drag control the sheet instead of scrolling. */
+    touch-action: none;
   }
 
   .sheet-grabber::before {
@@ -273,6 +291,33 @@
   #search-suggestions li {
     min-height: 44px;
     display: flex;
+    align-items: center;
+  }
+
+  /* Citation + panel controls to the 44px standard. Source chips are the
+     core "citeable by default" interaction — a fat-finger minefield at
+     the default ~19px, and opening the wrong source mid-research is
+     exactly the friction the product promises to remove. */
+  #sources-list {
+    gap: 8px;
+  }
+
+  #sources-list li a {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    padding: 9px 12px;
+  }
+
+  .panel-close {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  .cite-btn,
+  .sources-copy {
+    min-height: 44px;
+    display: inline-flex;
     align-items: center;
   }
 

--- a/src/styles/_responsive.css
+++ b/src/styles/_responsive.css
@@ -68,6 +68,13 @@
     display: none;
   }
 
+  /* In the explorer, keep the sheet short enough that the X/Y axis
+     selectors at the top of the scatter view stay reachable while a
+     tapped dot's details are showing. */
+  body.view-scatter.sheet-open #country-panel {
+    height: 66%;
+  }
+
   /* Sticky grab handle: a familiar "swipe / tap to dismiss" affordance
      that stays put while the sheet scrolls, so closing is always one
      tap away. The wide invisible ::after is the real touch target. */
@@ -283,6 +290,49 @@
      (and the touch-intent delay) when dragging across the map. */
   #map svg {
     touch-action: none;
+  }
+
+  /* Range inputs (filter Min/Max, timeline scrubber) get a real 24px
+     thumb and a taller grab zone — the default thin native thumb is
+     almost unhittable with a fingertip. Custom track drops the accent
+     progress fill, but every slider here shows its value in a readout. */
+  input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
+    height: 28px;
+    background: transparent;
+  }
+
+  input[type="range"]::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 2px;
+    background: var(--border);
+  }
+
+  input[type="range"]::-moz-range-track {
+    height: 4px;
+    border-radius: 2px;
+    background: var(--border);
+  }
+
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    margin-top: -10px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 2px solid var(--surface-raised);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+  }
+
+  input[type="range"]::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 2px solid var(--surface-raised);
   }
 
   .dimension-row {

--- a/src/styles/_scatter.css
+++ b/src/styles/_scatter.css
@@ -144,6 +144,12 @@ circle.scatter-dot:hover {
   pointer-events: none;
 }
 
+/* First-tap preview label (touch): tinted so it reads as "tap again to
+   open", distinct from the committed selection label. */
+.scatter-dot-label.is-preview {
+  fill: var(--accent);
+}
+
 @media (max-width: 768px) {
   .scatter-container {
     padding: 12px 14px 8px;

--- a/src/styles/_scatter.css
+++ b/src/styles/_scatter.css
@@ -150,7 +150,7 @@ circle.scatter-dot:hover {
   fill: var(--accent);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 768px), (max-height: 500px) and (pointer: coarse) {
   .scatter-container {
     padding: 12px 14px 8px;
   }

--- a/src/styles/_tokens.css
+++ b/src/styles/_tokens.css
@@ -23,6 +23,11 @@
   --radius-sm: 5px;
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
 
+  /* Shared height for every toolbar control (search, buttons, toggles)
+     so they line up on one baseline. Bumped to a 44px touch target on
+     coarse pointers in _responsive.css. */
+  --control-h: 36px;
+
   /* ---- Brand hue (used to tint neutrals) ---- */
   --brand-hue: 75;
 


### PR DESCRIPTION
## Summary

Transforms the mobile experience from a stacked two-panel layout to a modern bottom-sheet pattern for country details, paired with a collapsible header toolbar. The sheet slides up over the map on selection and back down on close, reclaiming vertical space for the map itself. Adds comprehensive touch-friendly controls (44px targets, drag-to-dismiss, preview-then-select on scatter plot) and responsive header that folds secondary controls behind a menu toggle on narrow viewports.

## Key Changes

**Mobile Layout & Sheet Behavior**
- Country detail panel now renders as a bottom sheet (absolutely positioned, slides in/out via `transform: translateY()`) instead of a second flex row
- Sheet anchored to `#app-main` (not viewport) so it never collides with header or timeline
- Added `body.sheet-open` class to control sheet visibility; footer hides when sheet is open to reclaim ~76px
- Grab handle (`.sheet-grabber`) with sticky positioning and drag-to-dismiss gesture support (pointer events, 30% threshold)
- Sheet height varies by view: 88% default, 66% in scatter explorer (keeps axis selectors reachable)
- Cite popover capped at 60dvh with internal scroll to prevent content being pushed off-screen

**Responsive Header**
- Mobile header now wraps into two rows: wordmark + menu toggle on top, search + score selector on bottom
- Menu toggle (`#menu-toggle`, ☰ icon) folds filter, scatter, and export controls behind `body.controls-open` class
- Theme toggle and freshness metadata stay visible (persistent theme + trust signal)
- Secondary controls (filter, scatter, export) hidden by default on mobile, revealed via menu
- Popovers anchor to header itself (not individual buttons) so they can't run off-screen; positioned as full-width panels below toolbar

**Touch & Coarse Pointer Enhancements**
- Unified `--control-h` CSS variable (44px on touch) for search, buttons, toggles, and range inputs
- Range input styling: 24px thumb, 4px track, custom appearance for better touch targets
- iOS Safari zoom prevention: all text inputs pinned to 16px font-size
- Map SVG: `touch-action: none` to prevent gesture tug-of-war (pan/pinch vs page scroll)
- Source chips and panel controls bumped to 44px minimum height
- Scatter plot: first tap previews a dot (pins its name), second tap commits selection; larger dots (6px base, 9.5px selected) on touch

**Responsive Media Queries**
- Tablet tier (769–1040px): compact sidebar, unchanged layout
- Mobile tier: `(max-width: 768px) or (max-height: 500px and pointer: coarse)` — catches landscape phones and short touch viewports
- Landscape phones (orientation: landscape, max-height: 500px, pointer: coarse): footer hidden, tighter padding, sheet claims 94% height
- Tablet tier now includes `min-height: 501px` guard to exclude landscape phones from cramped sidebar layout

**Scatter Plot Responsiveness**
- Chart now responsive: `WIDTH` and `HEIGHT` are measured from container (not fixed), updated on resize via `ResizeObserver`
- `layout()` function recalculates scales, axes, and labels on creation and whenever container changes
- Viewbox dynamically set to match actual pixel dimensions so plot fills portrait slots instead of letterboxing

**Panel & Scoring**
- Score bar fill now uses solid color (set via `--fill-color` CSS variable) instead of gradient, matching choropleth ramp
- Dimension dots colored by score position on ramp (via `--dot-color`)
- Confidence badge styling refined: high-confidence now uses `--text-secondary` instead of 0.65 opacity for legibility
- Panel scroll reset on every country selection (prevents opening mid-content after scrolling previous country)

**Search & Filtering**
- Empty search state now shows explicit "no matches" row instead of vanishing box
- Search suggestions list hidden when empty (`:empty` selector)
- Comparison search inputs get unique list IDs to avoid duplicate aria-controls

**Accessibility & Semantics**
- Sheet dialog:

https://claude.ai/code/session_01VJ1unQQTsbFU2xK4ebJPiX