### PR TITLE
Senior review: UX/a11y fixes, data + pipeline hardening, CI gates, and frontend architecture refactor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Frontend npm dependencies (d3, topojson, vite, typescript, playwright…).
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # One PR for the routine dev-tooling bumps instead of a dozen.
+      dev-dependencies:
+        dependency-type: development
+
+  # Python pipeline dependencies (anthropic, pydantic, typer, pytest…).
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # Keep the SHA-pinned GitHub Actions current (Dependabot updates both the
+  # pin and the version comment).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,26 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege: CI only needs to read the code. Any job that needs more
+# raises its own permissions block.
+permissions:
+  contents: read
+
+# A newer push to the same ref cancels the in-flight run — no point finishing
+# CI for a commit that's already been superseded.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -33,16 +44,53 @@ jobs:
       - name: Build
         run: npm run build
 
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Only Chromium — the smoke + axe suite is single-browser by design.
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        run: npm run build
+
+      - name: Run e2e smoke + accessibility checks
+        run: npm run test:e2e
+
+      - name: Upload Playwright report on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   pipeline:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -35,6 +35,16 @@ on:
         default: true
         type: boolean
 
+# Never let two data runs (a manual dispatch overlapping the monthly cron)
+# race to git push. cancel-in-progress: false queues the second run instead of
+# clobbering the first mid-write.
+concurrency:
+  group: update-data
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
   update-data:
     runs-on: ubuntu-latest
@@ -43,12 +53,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install dependencies
         run: pip install -r requirements.txt
@@ -86,9 +98,11 @@ jobs:
           git diff --cached --quiet || echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: Commit and push updated data
-        if: ${{ !cancelled() && steps.changes.outputs.changed == 'true' }}
+        # Only ever push from the default branch — a manual dispatch on some
+        # other ref must not write data commits there.
+        if: ${{ !cancelled() && steps.changes.outputs.changed == 'true' && github.ref == 'refs/heads/main' }}
         run: |
           git config user.name "AI Regulation Bot"
           git config user.email "bot@github-actions"
           git commit -m "chore: automated data update $(date -u +%Y-%m-%d)"
-          git push
+          git push origin HEAD:main

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 node_modules/
 dist/
 
+# Playwright e2e output
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/
+
 # macOS
 .DS_Store
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,12 @@ pip install -r requirements.txt
 
 ### Frontend (`src/`)
 
-Vanilla TypeScript + D3.js + TopoJSON, built with Vite. No framework.
+Vanilla TypeScript + D3.js + TopoJSON, built with Vite. No framework. Full
+pattern write-up (layering + mermaid diagrams: pub-sub store, the
+single-writer interactions orchestrator, the `mainView` FSM, selectors, the
+typed DOM seam) lives in [`src/ARCHITECTURE.md`](src/ARCHITECTURE.md).
 
-**The frontend is fully TypeScript** (strict mode, `tsc --noEmit` in CI). Relative imports are extensionless. The state shape lives in the `AppState` interface in `src/state/store.ts`; data row shapes (`ScoreEntry`, `RegulationEntry`) in `src/data/loader.ts`; the score-dimension unions (`AttributeKey`, `DimensionKey`) in `src/constants.ts`.
+**The frontend is fully TypeScript** (strict mode, `tsc --noEmit` in CI). Relative imports are extensionless. The state shape lives in the `AppState` interface in `src/state/store.ts`; data row shapes (`ScoreEntry`, `RegulationEntry`) in `src/data/loader.ts`; the score-dimension unions (`AttributeKey`, `DimensionKey`) in `src/constants.ts`. All state writes go through intents in `src/state/interactions.ts`; derived reads through `src/state/selectors.ts`.
 
 **Module structure:**
 

--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
           aria-controls="search-suggestions"
         />
         <ul id="search-suggestions" role="listbox" aria-label="Country suggestions"></ul>
+        <div id="search-status" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
       </div>
       <div id="score-btn-container">
         <button id="score-btn" aria-haspopup="listbox" aria-expanded="false">
@@ -123,13 +124,13 @@
         </button>
         <div id="filter-popover">
           <div class="filter-row">
-            <span class="filter-label">Min</span>
-            <input type="range" id="filter-min" min="1" max="5" step="0.25" value="1" aria-label="Minimum score">
+            <label class="filter-label" for="filter-min">Min</label>
+            <input type="range" id="filter-min" min="1" max="5" step="0.25" value="1" aria-label="Minimum score" aria-describedby="filter-min-label">
             <span id="filter-min-label">1</span>
           </div>
           <div class="filter-row">
-            <span class="filter-label">Max</span>
-            <input type="range" id="filter-max" min="1" max="5" step="0.25" value="5" aria-label="Maximum score">
+            <label class="filter-label" for="filter-max">Max</label>
+            <input type="range" id="filter-max" min="1" max="5" step="0.25" value="5" aria-label="Maximum score" aria-describedby="filter-max-label">
             <span id="filter-max-label">5</span>
           </div>
         </div>
@@ -187,6 +188,12 @@
         <div class="scatter-controls">
           <label>X <select id="scatter-x" aria-label="X axis dimension"></select></label>
           <label>Y <select id="scatter-y" aria-label="Y axis dimension"></select></label>
+          <span class="scatter-colorkey">
+            <span class="scatter-colorkey-text">Dot colour: maturity index</span>
+            <span class="scatter-colorkey-ends" aria-hidden="true">low</span>
+            <span class="scatter-colorkey-bar" aria-hidden="true"></span>
+            <span class="scatter-colorkey-ends" aria-hidden="true">high</span>
+          </span>
         </div>
         <div id="scatter-chart"></div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "topojson-client": "^3.1.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.61.1",
         "@types/d3-array": "^3.2.2",
         "@types/d3-axis": "^3.0.6",
         "@types/d3-dsv": "^3.0.7",
@@ -32,6 +34,19 @@
         "typescript-eslint": "^8.61.0",
         "vite": "^6.0.0",
         "vitest": "^4.1.8"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -676,6 +691,22 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.1",
@@ -1622,6 +1653,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {
@@ -2788,6 +2829,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,17 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "d3": "^7.9.0",
     "topojson-client": "^3.1.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.61.1",
     "@types/d3-array": "^3.2.2",
     "@types/d3-axis": "^3.0.6",
     "@types/d3-dsv": "^3.0.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// End-to-end smoke + accessibility checks. These run against the built
+// preview server, not the dev server, so they exercise what actually ships.
+// Vitest owns tests/*.test.js (unit); Playwright owns tests/e2e/*.spec.ts.
+const PORT = 4173;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: 'on-first-retry',
+    // In CI we `playwright install chromium` so the bundled browser is used.
+    // Locally, PW_CHROME_PATH can point at an already-present Chromium so the
+    // suite runs without a separate download.
+    ...(process.env.PW_CHROME_PATH
+      ? { launchOptions: { executablePath: process.env.PW_CHROME_PATH } }
+      : {}),
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  // Build already ran in CI; here we just serve dist. Reuse an
+  // already-running preview locally so the suite is quick to iterate on.
+  webServer: {
+    command: `npm run preview -- --port ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/scripts/regulation_pipeline/batch.py
+++ b/scripts/regulation_pipeline/batch.py
@@ -54,11 +54,13 @@ class BatchRunner:
         *,
         poll_interval: int = POLL_INTERVAL_SECONDS,
         max_wait: int = MAX_WAIT_SECONDS,
+        cancel_grace_seconds: int = CANCEL_GRACE_SECONDS,
         sleep: Callable[[float], None] = time.sleep,
     ):
         self._client = client
         self._poll_interval = poll_interval
         self._max_wait = max_wait
+        self._cancel_grace_seconds = cancel_grace_seconds
         self._sleep = sleep
 
     def research(self, params_by_country: dict[str, dict]) -> tuple[dict, list[str]]:
@@ -119,9 +121,10 @@ class BatchRunner:
 
     def _drain_after_cancel(self, batch):
         """Poll a canceled batch until it ends, so succeeded results are
-        collectable. Bounded by :data:`CANCEL_GRACE_SECONDS`."""
+        collectable. Bounded by ``cancel_grace_seconds`` (default
+        :data:`CANCEL_GRACE_SECONDS`)."""
         grace = 0
-        while batch.processing_status != "ended" and grace < CANCEL_GRACE_SECONDS:
+        while batch.processing_status != "ended" and grace < self._cancel_grace_seconds:
             self._sleep(self._poll_interval)
             grace += self._poll_interval
             batch = self._client.messages.batches.retrieve(batch.id)

--- a/scripts/regulation_pipeline/cli.py
+++ b/scripts/regulation_pipeline/cli.py
@@ -49,6 +49,10 @@ def _run(
     batch: bool = typer.Option(
         False, help="Use the Message Batches API: 50% token pricing, results within ~1h"
     ),
+    max_runtime_minutes: int = typer.Option(
+        0, help="Abort a sync run after this many minutes (0 = unbounded). Bounds the "
+        "worst case when the API is slow-but-not-failing. Ignored with --batch."
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose (DEBUG) logging"),
 ) -> None:
     """Update AI regulation data using the Claude API."""
@@ -59,7 +63,7 @@ def _run(
         logger.error("ANTHROPIC_API_KEY environment variable not set")
         raise typer.Exit(code=1)
 
-    settings = Settings(default_model=model)
+    settings = Settings(default_model=model).validate()
     today = date.today()
 
     # SDK-level silent retries are disabled — retry.py does explicit, logged
@@ -78,7 +82,11 @@ def _run(
     strategy = (
         BatchStrategy(research_client, BatchRunner(client), use_search_for)
         if batch
-        else SyncStrategy(research_client, use_search_for)
+        else SyncStrategy(
+            research_client,
+            use_search_for,
+            max_wall_seconds=max_runtime_minutes * 60 if max_runtime_minutes > 0 else None,
+        )
     )
 
     logger.info("Loading existing data...")

--- a/scripts/regulation_pipeline/config.py
+++ b/scripts/regulation_pipeline/config.py
@@ -69,6 +69,14 @@ class Settings:
     search_model: str = SEARCH_MODEL
     priority_countries: frozenset[str] = PRIORITY_COUNTRIES
 
+    def validate(self) -> Settings:
+        """Fail fast if ``root`` is misconfigured. Without this the error is
+        deferred to the first write deep inside :meth:`Dataset.save`, far from
+        the misconfiguration. Call once, right after construction."""
+        if not self.root.is_dir():
+            raise NotADirectoryError(f"Settings.root is not a directory: {self.root}")
+        return self
+
     @property
     def scores_csv(self) -> Path:
         return self.root / "public" / "scores.csv"

--- a/scripts/regulation_pipeline/models.py
+++ b/scripts/regulation_pipeline/models.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any, ClassVar, Literal
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict
+from pydantic import BaseModel, BeforeValidator, ConfigDict, model_validator
 
 
 def _reject_bool(value: Any) -> Any:
@@ -164,9 +164,21 @@ class ResearchResult(BaseModel):
         scores = [dim.score for dim in self.dimensions().values() if dim.normative]
         return round(sum(scores) / len(scores), 2)
 
+    @model_validator(mode="after")
+    def _cap_unsourced_confidence(self) -> "ResearchResult":
+        """Keep the model self-consistent with :meth:`effective_confidence`.
+        An unsourced claim is not citable, so it cannot carry more than "low"
+        confidence — enforce that at validation time, not only on write, so an
+        in-memory result never advertises a confidence its sources don't
+        support. (Using ``object.__setattr__`` to avoid re-triggering validation.)"""
+        if self.confidence != "low" and not self.sources.strip():
+            object.__setattr__(self, "confidence", "low")
+        return self
+
     def effective_confidence(self) -> Confidence:
         """Unsourced claims are not citable — cap confidence at "low" so the UI
-        flags them and staleness re-researches them."""
+        flags them and staleness re-researches them. The model validator above
+        already applies this, so this is now a stable, idempotent accessor."""
         return self.confidence if self.sources.strip() else "low"
 
     @classmethod

--- a/scripts/regulation_pipeline/names.py
+++ b/scripts/regulation_pipeline/names.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping
 
 
 class CountryNames:
     """Maps aliases (``"Czech Republic"``) to canonical names (``"Czechia"``).
 
     Load once from ``country_names.json`` and reuse; unknown names pass through
-    unchanged after stripping whitespace.
+    unchanged after stripping whitespace. The alias table is copied into a
+    read-only mapping so a caller can't accidentally mutate a shared lookup and
+    corrupt every subsequent ``canonical()`` call.
     """
 
-    def __init__(self, aliases: dict[str, str]):
-        self._aliases = aliases
+    def __init__(self, aliases: Mapping[str, str]):
+        self._aliases: Mapping[str, str] = MappingProxyType(dict(aliases))
 
     @classmethod
     def load(cls, path: Path) -> CountryNames:

--- a/scripts/regulation_pipeline/repository.py
+++ b/scripts/regulation_pipeline/repository.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import csv
 import io
 import json
+import logging
+import os
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -20,6 +22,8 @@ from . import history as history_mod
 from .config import REGULATION_FIELDS, SCORES_FIELDS, Settings
 from .models import ResearchResult
 from .names import CountryNames
+
+logger = logging.getLogger(__name__)
 
 _SCORE_COLUMNS = (
     "Regulation Status", "Policy Lever", "Governance Type",
@@ -82,6 +86,17 @@ class Dataset:
     def apply(self, country: str, result: ResearchResult, today: date) -> ApplyOutcome:
         """Fold one validated research result into all four stores."""
         version = int((self._scores.get(country, {}).get("Data Version", 1)) or 1)
+
+        # Audit trail: apply() overwrites in place, and history.json only
+        # captures dimension-score changes — a sources/confidence-only change
+        # would otherwise leave no record of what was replaced. Log the prior
+        # snapshot so an operator can reconstruct it from the run log.
+        prior = self._regulation.get(country)
+        if prior is not None:
+            logger.debug(
+                "overwriting %s (was: confidence=%s, sources=%r, last_updated=%s)",
+                country, prior.get("Confidence"), prior.get("Sources"), prior.get("Last Updated"),
+            )
 
         self._scores[country] = _scores_row(country, result, version + 1, today)
         self._regulation[country] = _regulation_row(country, result, today)
@@ -203,6 +218,15 @@ def _load_csv(path: Path, names: CountryNames) -> dict[str, dict]:
             canonical = names.canonical(row["Country"])
             row = dict(row)
             row["Country"] = canonical
+            # Normalize the one numeric column on load so the in-memory store
+            # doesn't mix a string version (fresh load) with the int apply()
+            # writes. Round-trips byte-identically (DictWriter renders both the
+            # same). Malformed/missing → 1.
+            if "Data Version" in row:
+                try:
+                    row["Data Version"] = int(row["Data Version"])
+                except (TypeError, ValueError):
+                    row["Data Version"] = 1
             rows[canonical] = row
     return rows
 
@@ -223,9 +247,29 @@ def _csv_text(rows_by_country: dict[str, dict], fieldnames: list[str]) -> str:
 
 
 def _write_text(path: Path, text: str) -> None:
-    """Atomically write ``text`` to ``path`` (tmp file + ``os.replace``) so an
-    interrupted write can never leave a half-written data file."""
+    """Atomically and durably write ``text`` to ``path`` (tmp file + fsync +
+    ``os.replace``) so an interrupted write can never leave a half-written data
+    file, and a power loss right after the run can't lose a committed month.
+
+    ``os.replace`` is atomic for the rename, but without fsync the bytes may
+    still be in the page cache when a CI/cloud runner is yanked. We fsync the
+    temp file before the swap, then fsync the containing directory so the
+    rename itself is on stable storage."""
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(text, encoding="utf-8", newline="")
+    # Write + flush + fsync the data before we swap it into place.
+    with tmp.open("w", encoding="utf-8", newline="") as f:
+        f.write(text)
+        f.flush()
+        os.fsync(f.fileno())
     tmp.replace(path)
+    # Persist the directory entry (the rename) too. Best-effort: some
+    # platforms/filesystems don't allow opening a directory for fsync.
+    try:
+        dir_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass

--- a/scripts/regulation_pipeline/staleness.py
+++ b/scripts/regulation_pipeline/staleness.py
@@ -10,7 +10,13 @@ class StalenessPolicy:
     empty/NA, its confidence is ``low``, or its ``Last Updated`` stamp is
     missing, unparseable, or older than ``staleness_days``. The reference date
     is injected so a run has one consistent "today" and the logic is testable
-    without patching the clock."""
+    without patching the clock.
+
+    Date-format contract: ``Last Updated`` is always a UTC date-only string
+    (``YYYY-MM-DD``), never a timestamp. Both ``today`` and the parsed
+    ``last_date`` are therefore timezone-naive ``date`` objects and the day
+    subtraction is unambiguous. If a timestamp with timezone is ever introduced
+    into the CSV, this parser must move to timezone-aware datetimes."""
 
     def __init__(self, staleness_days: int, today: date):
         self.staleness_days = staleness_days

--- a/scripts/regulation_pipeline/strategies.py
+++ b/scripts/regulation_pipeline/strategies.py
@@ -55,15 +55,31 @@ class SyncStrategy(ResearchStrategy):
         *,
         sleep: Callable[[float], None] = time.sleep,
         max_consecutive_failures: int = 5,
+        max_wall_seconds: float | None = None,
+        clock: Callable[[], float] = time.monotonic,
     ):
         self._client = client
         self._use_search_for = use_search_for
         self._sleep = sleep
         self._max_consecutive_failures = max_consecutive_failures
+        # Upper bound on total run time. The consecutive-failure breaker misses
+        # a "slow but not failing" degradation (every country succeeds after
+        # several retries), which can silently blow past the CI job budget.
+        # None disables the bound (default; the CLI sets a real ceiling).
+        self._max_wall_seconds = max_wall_seconds
+        self._clock = clock
 
     def research(self, countries: list[str], reg_rows: dict[str, dict]) -> Iterator[Answer]:
         consecutive = 0
+        started = self._clock()
         for i, country in enumerate(countries, 1):
+            if self._max_wall_seconds is not None:
+                elapsed = self._clock() - started
+                if elapsed > self._max_wall_seconds:
+                    raise FatalAPIError(
+                        f"run exceeded {self._max_wall_seconds:.0f}s wall-clock budget "
+                        f"after {i - 1}/{len(countries)} countries — aborting"
+                    )
             logger.info("[%d/%d] Researching %s...", i, len(countries), country)
             raw = self._client.research(
                 country, reg_rows.get(country), use_search=self._use_search_for(country)

--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -1,0 +1,176 @@
+# Frontend Architecture
+
+Vanilla TypeScript + D3 over a static `index.html`, built with Vite. No
+framework — the choropleth is the protagonist and the bundle stays small
+(~57 kB gzip). This document is the frontend counterpart to
+[`scripts/regulation_pipeline/README.md`](../scripts/regulation_pipeline/README.md):
+it names the patterns the code leans on and the seams that keep the concerns
+separable and testable.
+
+The through-line: **all state change flows one way.** A user gesture dispatches
+a named *intent*; the intent is the only thing that writes the store; the store
+notifies subscribers by key; subscribers re-render their slice of the DOM.
+Derived values are read through *selectors*, never recomputed inline.
+
+## Layering
+
+Dependencies point downward. Nothing below the orchestrator imports a feature,
+so there are no import cycles (`madge --circular src/` is clean).
+
+```mermaid
+flowchart TD
+  subgraph Leaf["Leaf (no app imports)"]
+    store["state/store.ts<br/>pub-sub + AppState"]
+    constants["constants.ts<br/>labels, MainView, MAX_COMPARISON"]
+    dom["dom.ts<br/>typed element accessors"]
+    colorSlots["comparison/colorSlots.ts<br/>stable colour assignment"]
+    dataLayer["data/*<br/>loaders, search index, blocs"]
+  end
+
+  subgraph Derive["Derived + orchestration"]
+    selectors["state/selectors.ts<br/>memoized reads (rank…)"]
+    interactions["state/interactions.ts<br/>the single WRITER — intents + invariants"]
+  end
+
+  subgraph Features["Features (subscribe + render)"]
+    map["map/*"]
+    panel["panel/*"]
+    comparison["comparison/*"]
+    scatter["scatter/*"]
+    controls["controls/*"]
+  end
+
+  root["main.ts<br/>composition root"]
+
+  interactions --> store
+  interactions --> constants
+  interactions --> colorSlots
+  selectors --> store
+  Features --> interactions
+  Features --> selectors
+  Features --> store
+  Features --> dom
+  Features --> dataLayer
+  root --> Features
+```
+
+## The patterns
+
+### Observer / pub-sub — `state/store.ts`
+A single `AppState` object plus a per-key listener registry. `getState()`
+returns it deeply read-only (mutation is a compile error); `setState(patch)`
+merges and **emits only for keys whose value actually changed** (no-op writes
+don't fan out re-renders); `on(key, handler)` subscribes and returns an
+unsubscribe. Listeners are typed per key (`Listener<K>`), so a handler for
+`selectedCountry` receives `string | null`, not `unknown`.
+
+### Single-writer orchestrator — `state/interactions.ts`
+The frontend's analogue of the backend `PipelineService`. Every transition that
+carries an invariant lives here as a named intent, and **intents are the only
+callers of `setState` for view/selection/comparison state**:
+
+- selection — `selectCountry`, `stepCountry` (arrow nav with wraparound)
+- comparison membership — `addToComparison` / `removeFromComparison` /
+  `toggleComparison` / `clearComparison` / `restoreComparison`
+- the view FSM — `showMap` / `openScatter` / `toggleScatter` /
+  `openComparison` / `escapeMainView`
+
+Because it depends only on the store, constants, and the colour-slot leaf, it
+never forms a cycle with the features that call it. The rules that used to be
+smeared across control modules ("opening scatter leaves comparison", "a
+comparison needs ≥2 countries", "Esc backs out one layer") now have one home.
+
+### Finite-state view — `MainView`
+The main area is one field, `mainView: 'map' | 'scatter' | 'comparison'`
+(`constants.ts`), not two independent booleans. "Both overlays open at once" is
+unrepresentable, and `setMainView` is the single writer, so switching to one
+view implicitly leaves the others — no manual "close the other" dance.
+
+### Selectors (memoized derived state) — `state/selectors.ts`
+The read-side counterpart to the orchestrator. `maturityRank(country)` derives
+the whole ranking once per data load (memoized on the `scoreData` reference)
+instead of the panel rebuilding an O(n²) scan on every selection. New
+derivations used in more than one place belong here.
+
+### Mapper / repository — `data/*`
+`loader.ts` maps CSV rows to typed domain objects (`ScoreEntry`,
+`RegulationEntry`) and validates at the boundary (non-numeric/out-of-range →
+`null`, never `NaN`). `history.ts`, `blocs.ts`, `subscores.ts`, and
+`searchIndex.ts` are the other read models. This is the layer that most
+resembles the backend's `Dataset` repository.
+
+### Facade barrels — `map/index.ts`, `comparison/index.ts`, `scatter/index.ts`
+Each feature exposes a curated surface and hides its internals (the D3 renderer,
+the radar builder, the colour slots). Cross-feature imports go through the
+barrel, not into private files.
+
+### Typed DOM seam — `dom.ts`
+`el<T>(id)` (required; throws with the id if missing) and `maybeEl<T>(id)`
+(optional) replace unchecked `getElementById(x) as HTMLInputElement` casts. One
+place to reason about the element contract.
+
+### Serialization seam — `controls/url.ts`
+State ⇄ URL query string, so any view is a shareable link. `buildPermalink`
+omits defaults (and the theme, for citations); `applyUrlState` restores through
+the same intents, with an explicit precedence (comparison > scatter > country).
+
+## Data flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant F as Feature (e.g. map)
+  participant I as interactions
+  participant S as store
+  participant Subs as Subscribers
+
+  U->>F: click country
+  F->>I: selectCountry(name)
+  I->>S: setState({ selectedCountry })
+  S->>S: changed? yes
+  S-->>Subs: emit('selectedCountry', name)
+  Subs->>Subs: panel renders, map highlights,<br/>url writes, menu closes…
+```
+
+## Module map
+
+| Path | Role | Pattern |
+|------|------|---------|
+| `state/store.ts` | `AppState` + typed pub-sub | Observer, single source of truth |
+| `state/interactions.ts` | intents + invariants (the only writer) | Orchestrator / "Service" |
+| `state/selectors.ts` | memoized derived reads | Selector |
+| `constants.ts` | labels, `MainView`, `MAX_COMPARISON` | shared contract |
+| `dom.ts` | typed element access | seam |
+| `data/*` | CSV/JSON → typed domain | Mapper / repository |
+| `map/*` | choropleth render, zoom, tooltip, legend | imperative D3 |
+| `panel/*` | country detail | subscriber view |
+| `comparison/*` | staging strip + full comparison | subscriber view (+ `colorSlots` leaf) |
+| `scatter/*` | dimension explorer | subscriber view |
+| `controls/*` | search, filter, blocs, export, timeline, url, theme, menu, help, cite | subscriber views |
+| `main.ts` | boot + wiring | composition root |
+
+## Where the rules live
+
+- **What can transition, and when** → `state/interactions.ts` (nowhere else
+  should write `mainView`, comparison membership, or drive Esc layering).
+- **What a value means once derived** → `state/selectors.ts`.
+- **What the data must look like** → `data/loader.ts` (the validation boundary).
+- **What DOM ids exist** → `dom.ts` accessors + `index.html`.
+
+## Extending
+
+- **Add UI state**: add the field to `AppState` (+ default), then `on(key, …)`
+  where it matters. If a change has to enforce a rule, add an *intent* rather
+  than calling `setState` from the feature.
+- **Add a derived value used in >1 place**: add a memoized selector.
+- **Add a view/overlay**: extend `MainView` and the `setMainView` guard; the
+  FSM keeps mutual exclusion automatic.
+
+## Known incremental migrations
+
+- `dom.ts` is adopted for the unchecked casts; the remaining
+  `getElementById(...)!` sites (correct type, just non-null) can move to `el()`
+  opportunistically.
+- Rendering is deliberately imperative. If the panel/comparison DOM churn ever
+  justifies it, a ~30-line tagged-template helper — not a framework — is the
+  intended next step; the map stays hand-written D3.

--- a/src/comparison/colorSlots.ts
+++ b/src/comparison/colorSlots.ts
@@ -1,0 +1,44 @@
+// Stable colour-slot assignment for the comparison set.
+//
+// A country keeps its colour for the lifetime of its presence in the
+// comparison — removing a middle country must not reshuffle the others'
+// colours (which happens if callers key off the array index). This lives in
+// its own leaf module (imports nothing but the palette) so both the map
+// renderer and the comparison panel can read slot colours without either
+// feature importing the other — that circular import was the old coupling.
+//
+// `syncColorSlots` is the single writer and is called by the interactions
+// orchestrator immediately before it commits a new comparison set, so every
+// subscriber that later reads a slot sees a fully-assigned map.
+
+import { MAX_COMPARISON } from '../constants';
+import { comparisonColor } from './colors';
+
+const colorSlots = new Map<string, number>(); // countryName -> 0..MAX_COMPARISON-1
+
+export function syncColorSlots(names: readonly string[]): void {
+  // Release slots for countries that left the list.
+  for (const name of [...colorSlots.keys()]) {
+    if (!names.includes(name)) colorSlots.delete(name);
+  }
+  // Assign slots to new countries, reusing the lowest free index.
+  const used = new Set(colorSlots.values());
+  for (const name of names) {
+    if (colorSlots.has(name)) continue;
+    for (let i = 0; i < MAX_COMPARISON; i++) {
+      if (!used.has(i)) {
+        colorSlots.set(name, i);
+        used.add(i);
+        break;
+      }
+    }
+  }
+}
+
+export function getColorIndex(name: string): number {
+  return colorSlots.get(name) ?? 0;
+}
+
+export function getColorFor(name: string): string {
+  return comparisonColor(getColorIndex(name));
+}

--- a/src/comparison/index.ts
+++ b/src/comparison/index.ts
@@ -1,79 +1,10 @@
-import { getState, setState, on } from '../state/store';
+import { getState, on } from '../state/store';
+import { openComparison, showMap, clearComparison } from '../state/interactions';
 import { renderComparisonPanel, clearComparisonPanel, renderAddBar, renderTray } from './panel';
-import { markComparisonCountries } from '../map/renderer';
-import { comparisonColor } from './colors';
 
-export const MAX_COMPARISON = 4;
-
-export function openComparisonView(): void {
-  if (getState().comparisonCountries.length >= 2) {
-    setState({ comparisonViewOpen: true });
-  }
-}
-
-export function closeComparisonView(): void {
-  setState({ comparisonViewOpen: false });
-}
-
-// Stable color-slot assignment so a country keeps its color for the
-// lifetime of its presence in the comparison. Without this, removing
-// a middle country reshuffles every other country's color (because
-// callers were using the array index).
-const colorSlots = new Map<string, number>(); // countryName -> 0..MAX_COMPARISON-1
-
-function syncColorSlots(names: readonly string[]): void {
-  // Release slots for countries that left the list.
-  for (const name of [...colorSlots.keys()]) {
-    if (!names.includes(name)) colorSlots.delete(name);
-  }
-  // Assign slots to new countries, reusing the lowest free index.
-  const used = new Set(colorSlots.values());
-  for (const name of names) {
-    if (colorSlots.has(name)) continue;
-    for (let i = 0; i < MAX_COMPARISON; i++) {
-      if (!used.has(i)) {
-        colorSlots.set(name, i);
-        used.add(i);
-        break;
-      }
-    }
-  }
-}
-
-export function getColorIndex(name: string): number {
-  return colorSlots.get(name) ?? 0;
-}
-
-export function getColorFor(name: string): string {
-  return comparisonColor(getColorIndex(name));
-}
-
-export function addToComparison(name: string | null): void {
-  const { comparisonCountries } = getState();
-  if (!name) return;
-  if (comparisonCountries.includes(name)) return;
-  if (comparisonCountries.length >= MAX_COMPARISON) return;
-  setState({ comparisonCountries: [...comparisonCountries, name] });
-}
-
-export function removeFromComparison(name: string): void {
-  const { comparisonCountries } = getState();
-  if (!comparisonCountries.includes(name)) return;
-  setState({ comparisonCountries: comparisonCountries.filter(c => c !== name) });
-}
-
-export function toggleComparison(name: string): void {
-  const { comparisonCountries } = getState();
-  if (comparisonCountries.includes(name)) {
-    removeFromComparison(name);
-  } else {
-    addToComparison(name);
-  }
-}
-
-export function clearComparison(): void {
-  setState({ comparisonCountries: [], comparisonViewOpen: false });
-}
+// Membership mutation, colour slots, and view transitions now live in the
+// interactions orchestrator and the colorSlots leaf. This module owns only the
+// comparison view's DOM: the staging strip, the full panel, and focus.
 
 export function initComparison(): void {
   const panelEl = document.getElementById('comparison-panel');
@@ -86,53 +17,49 @@ export function initComparison(): void {
   const stripCountEl = document.getElementById('comparison-strip-count');
 
   if (clearBtn) clearBtn.addEventListener('click', clearComparison);
-  if (backBtn) backBtn.addEventListener('click', closeComparisonView);
-  if (viewBtn) viewBtn.addEventListener('click', openComparisonView);
+  if (backBtn) backBtn.addEventListener('click', showMap);
+  if (viewBtn) viewBtn.addEventListener('click', openComparison);
 
-  // The comparison set lives as a pinned footer in the country panel
-  // while the user assembles it — visible the whole time you're picking
-  // countries, never over the map. It hides once the full view opens or
-  // the set is empty.
+  // The comparison set lives as a pinned footer in the country panel while the
+  // user assembles it — visible the whole time you're picking countries, never
+  // over the map. It hides once the full view opens or the set is empty.
   function updateStrip(): void {
-    const { comparisonCountries, comparisonViewOpen } = getState();
-    if (stripEl) stripEl.hidden = !(comparisonCountries.length >= 1 && !comparisonViewOpen);
+    const { comparisonCountries, mainView } = getState();
+    if (stripEl) stripEl.hidden = !(comparisonCountries.length >= 1 && mainView !== 'comparison');
   }
 
   on('comparisonCountries', (names) => {
-    syncColorSlots(names);
-    markComparisonCountries(names);
     if (countEl) countEl.textContent = String(names.length);
     if (stripCountEl) stripCountEl.textContent = String(names.length);
     renderTray(names);
     updateStrip();
 
-    // Can't compare fewer than two — drop out of the full view if the
-    // set falls below the threshold while it's open.
-    if (getState().comparisonViewOpen && names.length < 2) {
-      setState({ comparisonViewOpen: false });
-    } else if (getState().comparisonViewOpen) {
+    // Can't compare fewer than two — drop out of the full view if the set
+    // falls below the threshold while it's open.
+    if (getState().mainView === 'comparison' && names.length < 2) {
+      showMap();
+    } else if (getState().mainView === 'comparison') {
       // Set changed while viewing — re-render the table/radar.
       renderComparisonPanel(names);
     }
   });
 
-  // Remember what had focus when the full view took over, so closing it
-  // can hand focus back rather than dropping it on a now-hidden element.
+  // Remember what had focus when the full view took over, so closing it can
+  // hand focus back rather than dropping it on a now-hidden element.
   let focusBeforeView: HTMLElement | null = null;
 
-  on('comparisonViewOpen', (open) => {
+  on('mainView', (view) => {
+    const open = view === 'comparison';
     document.body.classList.toggle('view-compare', open);
     updateStrip();
 
     if (open) {
-      // Comparison and the scatter explorer both claim the main area.
-      if (getState().scatterOpen) setState({ scatterOpen: false });
       focusBeforeView = document.activeElement as HTMLElement | null;
       if (panelEl) panelEl.hidden = false;
       if (countryPanelEl) countryPanelEl.style.display = 'none';
       renderComparisonPanel(getState().comparisonCountries);
-      // The country panel may have just been hidden — move focus into
-      // the new region so keyboard users aren't stranded.
+      // The country panel may have just been hidden — move focus into the new
+      // region so keyboard users aren't stranded.
       backBtn?.focus();
     } else {
       if (panelEl) panelEl.hidden = true;
@@ -149,6 +76,6 @@ export function initComparison(): void {
   // While a set is being assembled, keep the add-bar's quick-add button
   // pointed at the most recently clicked country.
   on('selectedCountry', () => {
-    if (getState().comparisonViewOpen) renderAddBar();
+    if (getState().mainView === 'comparison') renderAddBar();
   });
 }

--- a/src/comparison/index.ts
+++ b/src/comparison/index.ts
@@ -21,7 +21,7 @@ export function closeComparisonView(): void {
 // callers were using the array index).
 const colorSlots = new Map<string, number>(); // countryName -> 0..MAX_COMPARISON-1
 
-function syncColorSlots(names: string[]): void {
+function syncColorSlots(names: readonly string[]): void {
   // Release slots for countries that left the list.
   for (const name of [...colorSlots.keys()]) {
     if (!names.includes(name)) colorSlots.delete(name);

--- a/src/comparison/panel.ts
+++ b/src/comparison/panel.ts
@@ -4,7 +4,9 @@ import type { DimensionKey } from '../constants';
 import { matchCountryNames } from '../data/countryMatch';
 import { cleanRegulationText } from '../panel/sections';
 import { renderRadar } from './radar';
-import { addToComparison, removeFromComparison, getColorFor, MAX_COMPARISON } from './index';
+import { addToComparison, removeFromComparison } from '../state/interactions';
+import { getColorFor } from './colorSlots';
+import { MAX_COMPARISON } from '../constants';
 
 const DETAIL_DIMENSIONS: DimensionKey[] = [
   'regulationStatus',

--- a/src/comparison/panel.ts
+++ b/src/comparison/panel.ts
@@ -156,7 +156,7 @@ function buildChip(name: string): HTMLElement {
   return chip;
 }
 
-function renderChips(names: string[]): void {
+function renderChips(names: readonly string[]): void {
   const container = document.getElementById('comparison-chips')!;
   container.replaceChildren();
   names.forEach(name => container.appendChild(buildChip(name)));
@@ -165,7 +165,7 @@ function renderChips(names: string[]): void {
 // The comparison set — a pinned footer in the country panel listing the
 // staged countries. The "View comparison" button (enabled at 2+) opens
 // the full view.
-export function renderTray(names: string[]): void {
+export function renderTray(names: readonly string[]): void {
   const chips = document.getElementById('tray-chips')!;
   const btn = document.getElementById('tray-view-btn') as HTMLButtonElement;
   chips.replaceChildren();
@@ -200,7 +200,7 @@ export function renderTray(names: string[]): void {
 // across the top, score + description together in each cell. Replaces
 // the old radar data table (numbers) AND the separate text grid, so
 // every label appears exactly once.
-function renderComparisonTable(names: string[]): void {
+function renderComparisonTable(names: readonly string[]): void {
   const container = document.getElementById('comparison-table')!;
   container.replaceChildren();
   // The flex columns fill the view for 2-3 countries; 4 may exceed the
@@ -311,7 +311,7 @@ function renderComparisonTable(names: string[]): void {
   container.appendChild(table);
 }
 
-export function renderComparisonPanel(names: string[]): void {
+export function renderComparisonPanel(names: readonly string[]): void {
   renderAddBar();
   renderChips(names);
 

--- a/src/comparison/panel.ts
+++ b/src/comparison/panel.ts
@@ -1,4 +1,5 @@
 import { getState } from '../state/store';
+import { el } from '../dom';
 import { ATTRIBUTE_LABELS } from '../constants';
 import type { DimensionKey } from '../constants';
 import { matchCountryNames } from '../data/countryMatch';
@@ -169,7 +170,7 @@ function renderChips(names: readonly string[]): void {
 // the full view.
 export function renderTray(names: readonly string[]): void {
   const chips = document.getElementById('tray-chips')!;
-  const btn = document.getElementById('tray-view-btn') as HTMLButtonElement;
+  const btn = el<HTMLButtonElement>('tray-view-btn');
   chips.replaceChildren();
   names.forEach(name => chips.appendChild(buildChip(name)));
 

--- a/src/comparison/radar.ts
+++ b/src/comparison/radar.ts
@@ -28,7 +28,7 @@ function angleFor(i: number): number {
   return -Math.PI / 2 + (i / RADAR_AXES.length) * Math.PI * 2;
 }
 
-export function renderRadar(containerEl: Element, countries: string[], scoreData: ScoreData): void {
+export function renderRadar(containerEl: Element, countries: readonly string[], scoreData: ScoreData): void {
   containerEl.replaceChildren();
 
   const svg = create('svg')

--- a/src/comparison/radar.ts
+++ b/src/comparison/radar.ts
@@ -4,7 +4,7 @@ import { lineRadial, curveLinearClosed } from 'd3-shape';
 import { ATTRIBUTE_LABELS } from '../constants';
 import type { AttributeKey } from '../constants';
 import type { ScoreData, ScoreEntry } from '../data/loader';
-import { getColorFor } from './index';
+import { getColorFor } from './colorSlots';
 
 // Axis order for the radar (6 axes). Keep averageScore first so the most
 // prominent axis is the composite score.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,18 @@ export type AttributeKey = keyof typeof ATTRIBUTE_LABELS;
 /** The five independently scored dimensions (averageScore is derived). */
 export type DimensionKey = Exclude<AttributeKey, 'averageScore'>;
 
+/**
+ * What owns the main area. Exactly one of these is active at a time — the map,
+ * the scatter explorer, or the full comparison view. Modeling it as one value
+ * (rather than two independent `scatterOpen`/`comparisonViewOpen` booleans)
+ * makes "both overlays open at once" unrepresentable and lets every transition
+ * flow through a single writer (see state/interactions.ts).
+ */
+export type MainView = 'map' | 'scatter' | 'comparison';
+
+/** Maximum countries in a side-by-side comparison. */
+export const MAX_COMPARISON = 4;
+
 export const LEGEND_ENDPOINTS: Record<AttributeKey, [string, string]> = {
   averageScore:     ['Minimal', 'Comprehensive'],
   regulationStatus: ['Minimal', 'Comprehensive'],

--- a/src/controls/blocSummary.ts
+++ b/src/controls/blocSummary.ts
@@ -3,6 +3,7 @@
 // highest / lowest scoring members as jump links.
 
 import { getState, setState, on } from '../state/store';
+import { selectCountry } from '../state/interactions';
 import { computeBlocStats } from '../data/blocs';
 import type { BlocMemberScore } from '../data/blocs';
 import { ATTRIBUTE_LABELS } from '../constants';
@@ -22,7 +23,7 @@ function memberLink(label: string, member: BlocMemberScore): HTMLDivElement {
   btn.type = 'button';
   btn.className = 'bloc-member-link';
   btn.textContent = `${member.name} (${member.score})`;
-  btn.addEventListener('click', () => setState({ selectedCountry: member.name }));
+  btn.addEventListener('click', () => selectCountry(member.name));
 
   wrap.append(tag, btn);
   return wrap;

--- a/src/controls/citation.ts
+++ b/src/controls/citation.ts
@@ -8,7 +8,7 @@ const DEFAULT_MODE = 'averageScore';
 
 export interface CitationView {
   country?: string | null;
-  compareCountries?: string[] | null;
+  compareCountries?: readonly string[] | null;
   mode?: string | null;
   timelineDate?: string | null;
   url: string;

--- a/src/controls/citePopover.ts
+++ b/src/controls/citePopover.ts
@@ -48,7 +48,7 @@ async function copyToClipboard(text: string, confirmBtn: HTMLButtonElement): Pro
 
 function renderRows() {
   const state = getState();
-  const url = buildPermalink(state);
+  const url = buildPermalink(state, { omitTheme: true });
   const citations = citationsFor({
     country: state.selectedCountry,
     compareCountries: state.comparisonCountries,
@@ -133,7 +133,13 @@ function onDocClick(e: MouseEvent): void {
 }
 
 function onDocKey(e: KeyboardEvent): void {
-  if (e.key === 'Escape') closePopover();
+  if (e.key === 'Escape') {
+    closePopover();
+    // Keyboard dismissal must return focus to the trigger, or focus is
+    // stranded on document.body. (Outside-click dismissal deliberately
+    // does not, so the click's own target keeps focus.)
+    buttonEl?.focus();
+  }
 }
 
 export function initCitePopover(): void {

--- a/src/controls/filter.ts
+++ b/src/controls/filter.ts
@@ -1,10 +1,11 @@
 import { getState, setState, on } from '../state/store';
+import { el } from '../dom';
 
 export function initFilter(): void {
   const btn = document.getElementById('filter-btn')!;
   const popover = document.getElementById('filter-popover')!;
-  const minSlider = document.getElementById('filter-min') as HTMLInputElement;
-  const maxSlider = document.getElementById('filter-max') as HTMLInputElement;
+  const minSlider = el<HTMLInputElement>('filter-min');
+  const maxSlider = el<HTMLInputElement>('filter-max');
   const minLabel = document.getElementById('filter-min-label')!;
   const maxLabel = document.getElementById('filter-max-label')!;
 

--- a/src/controls/helpOverlay.ts
+++ b/src/controls/helpOverlay.ts
@@ -3,20 +3,22 @@
 // search.js) or the header ? button (wired here). Esc and backdrop
 // click close it for free via <dialog> semantics.
 
+import { maybeEl } from '../dom';
+
 export function openHelpOverlay(): void {
-  const dialog = document.getElementById('help-overlay') as HTMLDialogElement | null;
+  const dialog = maybeEl<HTMLDialogElement>('help-overlay');
   if (dialog && !dialog.open && typeof dialog.showModal === 'function') {
     dialog.showModal();
   }
 }
 
 export function closeHelpOverlay(): void {
-  const dialog = document.getElementById('help-overlay') as HTMLDialogElement | null;
+  const dialog = maybeEl<HTMLDialogElement>('help-overlay');
   if (dialog && dialog.open) dialog.close();
 }
 
 export function initHelpOverlay(): void {
-  const dialog = document.getElementById('help-overlay') as HTMLDialogElement | null;
+  const dialog = maybeEl<HTMLDialogElement>('help-overlay');
   if (!dialog) return;
 
   document.getElementById('help-overlay-close')

--- a/src/controls/menu.ts
+++ b/src/controls/menu.ts
@@ -35,6 +35,5 @@ export function initMenu(): void {
   // Selecting a country (sheet) or opening a full view takes over the
   // screen, so collapse the menu rather than leave it hanging.
   on('selectedCountry', (name) => { if (name) setOpen(false); });
-  on('scatterOpen', (open) => { if (open) setOpen(false); });
-  on('comparisonViewOpen', (open) => { if (open) setOpen(false); });
+  on('mainView', (view) => { if (view !== 'map') setOpen(false); });
 }

--- a/src/controls/search.ts
+++ b/src/controls/search.ts
@@ -1,4 +1,5 @@
 import { getState } from '../state/store';
+import { el, maybeEl } from '../dom';
 import { selectCountry, stepCountry, escapeMainView } from '../state/interactions';
 import { updateSearchHighlight } from '../map/index';
 import { matchCountryNames } from '../data/countryMatch';
@@ -44,7 +45,7 @@ function snippetNode(match: SearchMatch): HTMLSpanElement {
 }
 
 export function initSearch(): void {
-  const searchInput = document.getElementById('country-search') as HTMLInputElement;
+  const searchInput = el<HTMLInputElement>('country-search');
   const suggestions = document.getElementById('search-suggestions')!;
   // The options list is role="listbox" with presentational section
   // labels, so screen readers don't announce result changes on their
@@ -202,7 +203,7 @@ export function initKeyboardNav(): void {
 
     if (e.key === '?') {
       e.preventDefault();
-      const dialog = document.getElementById('help-overlay') as HTMLDialogElement | null;
+      const dialog = maybeEl<HTMLDialogElement>('help-overlay');
       if (dialog && !dialog.open && typeof dialog.showModal === 'function') {
         dialog.showModal();
       }

--- a/src/controls/search.ts
+++ b/src/controls/search.ts
@@ -1,4 +1,5 @@
-import { getState, setState } from '../state/store';
+import { getState } from '../state/store';
+import { selectCountry, stepCountry, escapeMainView } from '../state/interactions';
 import { updateSearchHighlight } from '../map/index';
 import { matchCountryNames } from '../data/countryMatch';
 import { buildSearchIndex, searchRegulationText, FIELD_LABELS } from '../data/searchIndex';
@@ -52,12 +53,12 @@ export function initSearch(): void {
   const statusRegion = document.getElementById('search-status');
   const announce = (msg: string) => { if (statusRegion) statusRegion.textContent = msg; };
 
-  const selectCountry = (name: string) => {
+  const pickSuggestion = (name: string) => {
     searchInput.value = name;
     suggestions.replaceChildren();
     announce('');
     updateSearchHighlight(null);
-    setState({ selectedCountry: name });
+    selectCountry(name);
   };
 
   const updateSuggestions = (query: string) => {
@@ -108,7 +109,7 @@ export function initSearch(): void {
       const li = document.createElement('li');
       li.textContent = name;
       li.setAttribute('role', 'option');
-      li.addEventListener('click', () => selectCountry(name));
+      li.addEventListener('click', () => pickSuggestion(name));
       suggestions.appendChild(li);
     }
 
@@ -133,7 +134,7 @@ export function initSearch(): void {
       head.append(country, field);
 
       li.append(head, snippetNode(match));
-      li.addEventListener('click', () => selectCountry(match.country));
+      li.addEventListener('click', () => pickSuggestion(match.country));
       suggestions.appendChild(li);
     }
   };
@@ -215,22 +216,13 @@ export function initKeyboardNav(): void {
     }
 
     if (e.key === 'Escape') {
-      // Esc backs out one layer at a time: full views first (explorer,
-      // then comparison), then selection/dropdowns on later presses.
-      // The cite popover is the innermost layer and owns its own Esc
-      // (it closes and restores focus to the Cite button) — bail here so
-      // we don't also deselect the country and hide the button underneath.
+      // Esc backs out one layer at a time: the cite popover owns its own Esc
+      // (closes + restores focus), then an overlay view (scatter/comparison)
+      // via the orchestrator, then selection/dropdowns on later presses.
       const citePopover = document.getElementById('cite-popover');
       if (citePopover && !citePopover.hidden) return;
-      if (getState().scatterOpen) {
-        setState({ scatterOpen: false });
-        return;
-      }
-      if (getState().comparisonViewOpen) {
-        setState({ comparisonViewOpen: false });
-        return;
-      }
-      setState({ selectedCountry: null });
+      if (escapeMainView()) return;
+      selectCountry(null);
       document.getElementById('score-dropdown')!.classList.remove('open');
       document.getElementById('score-btn')!.classList.remove('active');
       document.getElementById('filter-popover')!.classList.remove('open');
@@ -240,16 +232,9 @@ export function initKeyboardNav(): void {
       return;
     }
 
-    const { sortedCountryNames, selectedCountry } = getState();
-    if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && sortedCountryNames.length > 0) {
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
       e.preventDefault();
-      let idx = selectedCountry ? sortedCountryNames.indexOf(selectedCountry) : -1;
-      if (e.key === 'ArrowRight') {
-        idx = idx < sortedCountryNames.length - 1 ? idx + 1 : 0;
-      } else {
-        idx = idx > 0 ? idx - 1 : sortedCountryNames.length - 1;
-      }
-      setState({ selectedCountry: sortedCountryNames[idx] });
+      stepCountry(e.key === 'ArrowRight' ? 1 : -1);
     }
   });
 }

--- a/src/controls/search.ts
+++ b/src/controls/search.ts
@@ -45,10 +45,17 @@ function snippetNode(match: SearchMatch): HTMLSpanElement {
 export function initSearch(): void {
   const searchInput = document.getElementById('country-search') as HTMLInputElement;
   const suggestions = document.getElementById('search-suggestions')!;
+  // The options list is role="listbox" with presentational section
+  // labels, so screen readers don't announce result changes on their
+  // own — and a no-results message inside it is invisible to AT. This
+  // out-of-band polite region speaks the outcome instead.
+  const statusRegion = document.getElementById('search-status');
+  const announce = (msg: string) => { if (statusRegion) statusRegion.textContent = msg; };
 
   const selectCountry = (name: string) => {
     searchInput.value = name;
     suggestions.replaceChildren();
+    announce('');
     updateSearchHighlight(null);
     setState({ selectedCountry: name });
   };
@@ -57,6 +64,7 @@ export function initSearch(): void {
     suggestions.replaceChildren();
     if (query.length < 2) {
       updateSearchHighlight(null);
+      announce('');
       return;
     }
 
@@ -81,6 +89,7 @@ export function initSearch(): void {
       empty.setAttribute('role', 'presentation');
       empty.textContent = `No countries or policies match “${query}”`;
       suggestions.appendChild(empty);
+      announce(`No countries or policies match ${query}`);
       return;
     }
 
@@ -88,6 +97,9 @@ export function initSearch(): void {
       ...countryMatches,
       ...textMatches.map(m => m.country),
     ]));
+
+    const total = countryMatches.length + textMatches.length;
+    announce(`${total} ${total === 1 ? 'result' : 'results'} for ${query}`);
 
     if (countryMatches.length > 0 && textMatches.length > 0) {
       suggestions.appendChild(sectionLabel('Countries'));
@@ -154,8 +166,13 @@ export function initSearch(): void {
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       idx = Math.max(idx - 1, 0);
-    } else if (e.key === 'Enter' && highlighted) {
-      highlighted.click();
+    } else if (e.key === 'Enter') {
+      // Enter commits the highlighted option, or — when the user typed a
+      // query and hit Enter without arrowing — the first (top) option.
+      // Previously Enter with no highlight did nothing, so typing a full
+      // country name and pressing Enter was a dead end.
+      e.preventDefault();
+      (highlighted ?? items[0]).click();
       return;
     } else if (e.key === 'Escape') {
       suggestions.replaceChildren();
@@ -200,6 +217,11 @@ export function initKeyboardNav(): void {
     if (e.key === 'Escape') {
       // Esc backs out one layer at a time: full views first (explorer,
       // then comparison), then selection/dropdowns on later presses.
+      // The cite popover is the innermost layer and owns its own Esc
+      // (it closes and restores focus to the Cite button) — bail here so
+      // we don't also deselect the country and hide the button underneath.
+      const citePopover = document.getElementById('cite-popover');
+      if (citePopover && !citePopover.hidden) return;
       if (getState().scatterOpen) {
         setState({ scatterOpen: false });
         return;

--- a/src/controls/timeline.ts
+++ b/src/controls/timeline.ts
@@ -1,4 +1,5 @@
 import { getState, setState, on } from '../state/store';
+import { el } from '../dom';
 import { updateMap } from '../map/index';
 import { buildScoresAtDate, extractSortedDates } from '../data/history';
 import type { HistoryData, HistorySnapshot } from '../data/history';
@@ -28,7 +29,7 @@ export function initTimeline(history: HistoryData | null): void {
   const container = document.getElementById('timeline-strip')!;
   container.style.display = 'block';
 
-  const slider = document.getElementById('timeline-slider') as HTMLInputElement;
+  const slider = el<HTMLInputElement>('timeline-slider');
   slider.max = String(sortedDates.length - 1);
 
   const dateLabel = document.getElementById('timeline-date-label')!;

--- a/src/controls/url.ts
+++ b/src/controls/url.ts
@@ -98,7 +98,15 @@ export function parseUrl(search: string = window.location.search): UrlState {
 
 // Build a query string from the current (or supplied) state. Omits any
 // key whose value matches the app default so the URL stays short.
-export function buildPermalink(stateSnapshot?: AppState): string {
+//
+// `omitTheme` drops the theme param: a citation permalink identifies the
+// DATA VIEW, and light-vs-dark is a display preference that has no place
+// in a scholarly footnote. Share links keep it (a recipient sees your
+// theme); citations don't.
+export function buildPermalink(
+  stateSnapshot?: AppState,
+  { omitTheme = false }: { omitTheme?: boolean } = {}
+): string {
   const s = stateSnapshot || getState();
   const params = new URLSearchParams();
 
@@ -130,7 +138,7 @@ export function buildPermalink(stateSnapshot?: AppState): string {
   }
 
   const theme = document.documentElement.getAttribute('data-theme');
-  if (theme === 'light' || theme === 'dark') {
+  if (!omitTheme && (theme === 'light' || theme === 'dark')) {
     params.set('theme', theme);
   }
 

--- a/src/controls/url.ts
+++ b/src/controls/url.ts
@@ -11,9 +11,9 @@
 
 import { getState, setState, on } from '../state/store';
 import type { AppState } from '../state/store';
-import { SCORE_OPTIONS } from '../constants';
+import { restoreComparison, selectCountry, openScatter } from '../state/interactions';
+import { SCORE_OPTIONS, MAX_COMPARISON } from '../constants';
 import type { AttributeKey } from '../constants';
-import { MAX_COMPARISON } from '../comparison/index';
 
 /** State parsed from the URL — only keys present in the query appear. */
 export interface UrlState {
@@ -114,7 +114,7 @@ export function buildPermalink(
   // open). A staged-but-not-yet-viewed set is in-app ephemeral state,
   // so the URL keeps tracking the selected country until the user
   // actually opens the comparison.
-  if (s.comparisonViewOpen && s.comparisonCountries && s.comparisonCountries.length >= 2) {
+  if (s.mainView === 'comparison' && s.comparisonCountries && s.comparisonCountries.length >= 2) {
     params.set('compare', s.comparisonCountries.join(','));
   } else if (s.selectedCountry) {
     params.set('country', s.selectedCountry);
@@ -132,7 +132,7 @@ export function buildPermalink(
     params.set('bloc', s.selectedBloc);
   }
 
-  if (s.scatterOpen) {
+  if (s.mainView === 'scatter') {
     const isDefault = s.scatterX === DEFAULT_SCATTER_X && s.scatterY === DEFAULT_SCATTER_Y;
     params.set('scatter', isDefault ? '1' : `${s.scatterX},${s.scatterY}`);
   }
@@ -187,32 +187,27 @@ function applyUrlState(urlState: UrlState, { initial = false }: { initial?: bool
     setState({ selectedBloc: null });
   }
 
+  // Scatter axes are independent of which view is showing; apply them first.
   if (urlState.scatter) {
-    setState({
-      scatterOpen: true,
-      scatterX: urlState.scatter.x,
-      scatterY: urlState.scatter.y,
-    });
-  } else if (!initial) {
-    setState({ scatterOpen: false });
+    setState({ scatterX: urlState.scatter.x, scatterY: urlState.scatter.y });
   }
 
-  // Comparison wins over country — the comparison panel takes the
-  // right-hand slot either way.
+  // The main view is a single slot, so precedence is explicit:
+  // comparison (a shared compare link opens it directly) > scatter > map.
   const { scoreData } = getState();
   const validCountry = (name: string) => !!scoreData[name];
+  const compareValid = (urlState.compare || []).filter(validCountry);
 
-  if (urlState.compare && urlState.compare.length >= 2) {
-    const valid = urlState.compare.filter(validCountry);
-    // A shared compare link opens the full view directly.
-    setState({ comparisonCountries: valid, comparisonViewOpen: valid.length >= 2 });
+  if (compareValid.length >= 2) {
+    restoreComparison(compareValid);
   } else {
-    setState({ comparisonCountries: [], comparisonViewOpen: false });
+    restoreComparison([]); // clears the set and returns to the map view
     if (urlState.country && validCountry(urlState.country)) {
-      setState({ selectedCountry: urlState.country });
+      selectCountry(urlState.country);
     } else if (!initial) {
-      setState({ selectedCountry: null });
+      selectCountry(null);
     }
+    if (urlState.scatter) openScatter();
   }
 }
 
@@ -221,11 +216,10 @@ function applyUrlState(urlState: UrlState, { initial = false }: { initial?: bool
 export function initUrlSync(): void {
   on('selectedCountry', writeReplace);
   on('comparisonCountries', writeReplace);
-  on('comparisonViewOpen', writeReplace);
+  on('mainView', writeReplace);
   on('currentAttribute', writeReplace);
   on('timelineDate', writeReplace);
   on('selectedBloc', writeReplace);
-  on('scatterOpen', writeReplace);
   on('scatterX', writeReplace);
   on('scatterY', writeReplace);
 

--- a/src/data/countryMatch.ts
+++ b/src/data/countryMatch.ts
@@ -8,7 +8,7 @@ export interface MatchOptions {
 }
 
 export function matchCountryNames(
-  names: string[],
+  names: readonly string[],
   query: string,
   { limit = 8, exclude = null }: MatchOptions = {}
 ): string[] {

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -30,19 +30,40 @@ export interface RegulationEntry {
 export type ScoreData = Record<string, ScoreEntry>;
 export type RegulationData = Record<string, RegulationEntry>;
 
+// Valid dimension scores live in [1, 5] (methodology v2 allows
+// quarter-point decimals). Parse defensively: the old `+(x) || null`
+// idiom let a non-numeric cell through as NaN — `NaN || null` is NaN,
+// not null — and NaN then flows into the color scale and filter math.
+// This returns a clean number-or-null so the boundary is trustworthy.
+const SCORE_MIN = 1;
+const SCORE_MAX = 5;
+
+function parseScore(raw: string | undefined): number | null {
+  if (raw == null || raw === '') return null;
+  const v = Number(raw);
+  return Number.isFinite(v) && v >= SCORE_MIN && v <= SCORE_MAX ? v : null;
+}
+
 export async function loadScores(): Promise<ScoreData> {
-  const rows = await csv<ScoreEntry>('/scores.csv', d => ({
-    country: d.Country ?? '',
-    regulationStatus: +(d['Regulation Status'] ?? '') || null,
-    policyLever: +(d['Policy Lever'] ?? '') || null,
-    governanceType: +(d['Governance Type'] ?? '') || null,
-    actorInvolvement: +(d['Actor Involvement'] ?? '') || null,
-    averageScore: +(d['Average Score'] ?? '') || null,
-    enforcementLevel: d['Enforcement Level'] ? +d['Enforcement Level'] : null,
-    lastUpdated: d['Last Updated'] || null,
-    dataVersion: +(d['Data Version'] ?? '') || 1,
-  }));
-  return Object.fromEntries(rows.map(d => [d.country, d]));
+  const rows = await csv<ScoreEntry>('/scores.csv', d => {
+    const version = Number(d['Data Version'] ?? '');
+    return {
+      country: d.Country ?? '',
+      regulationStatus: parseScore(d['Regulation Status']),
+      policyLever: parseScore(d['Policy Lever']),
+      governanceType: parseScore(d['Governance Type']),
+      actorInvolvement: parseScore(d['Actor Involvement']),
+      averageScore: parseScore(d['Average Score']),
+      enforcementLevel: parseScore(d['Enforcement Level']),
+      lastUpdated: d['Last Updated'] || null,
+      dataVersion: Number.isFinite(version) && version >= 1 ? version : 1,
+    };
+  });
+  // Drop rows with no country key — a blank/garbled line must not create
+  // an empty-string entry that later renders as a ghost country.
+  return Object.fromEntries(
+    rows.filter(d => d.country).map(d => [d.country, d])
+  );
 }
 
 export async function loadRegulation(): Promise<RegulationData> {

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,0 +1,27 @@
+// Typed element access — the one seam for reaching into the DOM.
+//
+// The app is vanilla TS over a static index.html, so most modules resolve
+// elements by id. Left ad hoc, that meant `document.getElementById('x') as
+// HTMLInputElement` (an unchecked cast that lies if the id is wrong or the
+// element is the wrong tag) scattered across the codebase. These two helpers
+// centralise it:
+//
+//   el<T>(id)      — a REQUIRED shell element (declared in index.html). Throws
+//                    immediately with the offending id if it's missing, so a
+//                    renamed id fails loudly at startup instead of as a later
+//                    `null` dereference.
+//   maybeEl<T>(id) — an OPTIONAL element; returns null when absent, for the
+//                    defensively-guarded call sites.
+//
+// The type parameter documents the expected element type at the call site
+// without the bare `as` cast.
+
+export function el<T extends HTMLElement = HTMLElement>(id: string): T {
+  const node = document.getElementById(id);
+  if (!node) throw new Error(`dom: required element #${id} not found`);
+  return node as T;
+}
+
+export function maybeEl<T extends HTMLElement = HTMLElement>(id: string): T | null {
+  return document.getElementById(id) as T | null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import './styles/main.css';
 
 import { setState } from './state/store';
+import { restoreComparison, selectCountry, openScatter } from './state/interactions';
 import { loadScores, loadRegulation } from './data/loader';
 import { loadHistory } from './data/history';
 import { loadBlocs } from './data/blocs';
@@ -106,11 +107,7 @@ async function main(): Promise<void> {
   initOnboarding();
 
   if (urlState.scatter) {
-    setState({
-      scatterOpen: true,
-      scatterX: urlState.scatter.x,
-      scatterY: urlState.scatter.y,
-    });
+    setState({ scatterX: urlState.scatter.x, scatterY: urlState.scatter.y });
   }
 
   // Render map
@@ -128,10 +125,11 @@ async function main(): Promise<void> {
   if (urlState.compare && urlState.compare.length >= 2) {
     const valid = urlState.compare.filter(name => scoreData[name]);
     // A shared compare link opens the full comparison view directly.
-    if (valid.length >= 2) setState({ comparisonCountries: valid, comparisonViewOpen: true });
+    if (valid.length >= 2) restoreComparison(valid);
   } else if (urlState.country && scoreData[urlState.country]) {
-    setState({ selectedCountry: urlState.country });
+    selectCountry(urlState.country);
   }
+  if (urlState.scatter) openScatter();
 
   // Header info
   updateSiteLastUpdated(scoreData);

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -38,16 +38,32 @@ function announceCountry(name: string | null) {
     : `Selected ${name}. No ${label} data.`;
 }
 
+// Coalesce map recolors to one per frame. Several state keys can flip in
+// the same tick (a reset writes filterMin + filterMax + selectedBloc; the
+// store already drops no-op writes, but genuine multi-key changes still
+// fan out). Without this, each key queued its own full-map 500ms
+// transition and they stacked up during a slider drag. rAF collapses a
+// burst into a single updateMap.
+let mapUpdatePending = false;
+function scheduleUpdateMap(): void {
+  if (mapUpdatePending) return;
+  mapUpdatePending = true;
+  requestAnimationFrame(() => {
+    mapUpdatePending = false;
+    updateMap();
+  });
+}
+
 export function initMapSubscriptions() {
   on('currentAttribute', () => {
-    updateMap();
+    scheduleUpdateMap();
     updateLegendLabels();
     announceMode();
   });
 
   on('selectedCountry', announceCountry);
 
-  on('filterMin', () => updateMap());
-  on('filterMax', () => updateMap());
-  on('selectedBloc', () => updateMap());
+  on('filterMin', scheduleUpdateMap);
+  on('filterMax', scheduleUpdateMap);
+  on('selectedBloc', scheduleUpdateMap);
 }

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -1,5 +1,5 @@
 import { on, getState } from '../state/store';
-import { generateMap, updateMap } from './renderer';
+import { generateMap, updateMap, markComparisonCountries } from './renderer';
 import { updateLegendLabels } from './legend';
 import { ATTRIBUTE_LABELS, LEGEND_ENDPOINTS } from '../constants';
 
@@ -66,4 +66,9 @@ export function initMapSubscriptions() {
   on('filterMin', scheduleUpdateMap);
   on('filterMax', scheduleUpdateMap);
   on('selectedBloc', scheduleUpdateMap);
+
+  // The map paints its own comparison markers. Colour slots are assigned by
+  // the interactions orchestrator before this fires, so the indices are ready.
+  // (Owning this here is what lets comparison/ stop importing the renderer.)
+  on('comparisonCountries', markComparisonCountries);
 }

--- a/src/map/renderer.ts
+++ b/src/map/renderer.ts
@@ -14,6 +14,7 @@ import { getState, setState } from '../state/store';
 import type { ScoreData, ScoreEntry } from '../data/loader';
 import type { HistorySnapshot } from '../data/history';
 import { makeColorScale, addLegend } from './legend';
+import type { ColorScale } from './legend';
 import { createTooltip, showTooltip, hideTooltip } from './tooltip';
 import { setupZoom } from './zoom';
 import type { ZoomHandle } from './zoom';
@@ -43,6 +44,21 @@ let pathRef: GeoPath | null = null;
 let graticuleRef: MultiLineString | null = null;
 let currentSize: Size = { w: 1000, h: 500 };
 let zoomHandle: ZoomHandle | null = null;
+
+// Resolve a country's fill. The color scale clamps its domain, but a
+// null/NaN score must read as "no data" grey, not as the low-end color
+// (a clamped scale maps null→0→domain floor). One guard, three callers
+// (initial paint, theme swap, updateMap) so the boundary stays honest.
+function fillFor(
+  entry: MapScoreEntry | undefined,
+  attr: AttributeKey,
+  colorScale: ColorScale
+): string {
+  const value = entry ? entry[attr] : null;
+  return value != null && Number.isFinite(value)
+    ? colorScale(value)
+    : cssVar('--no-data');
+}
 
 function readContainerSize(): Size {
   const wrapper = document.getElementById('map-wrapper');
@@ -202,10 +218,7 @@ export async function generateMap(): Promise<void> {
     .enter().append('path')
     .attr('class', 'country')
     .attr('d', path)
-    .attr('fill', d => {
-      const entry = scoreData[d.properties.name];
-      return entry ? colorScale(entry[currentAttribute] as number) : cssVar('--no-data');
-    })
+    .attr('fill', d => fillFor(scoreData[d.properties.name], currentAttribute, colorScale))
     .attr('stroke', cssVar('--map-stroke'))
     .attr('stroke-width', 0.3)
     .on('mouseover', function (event: MouseEvent, d) {
@@ -261,10 +274,7 @@ export async function generateMap(): Promise<void> {
     const { scoreData: sd, currentAttribute: attr } = getState();
     selectAll<SVGPathElement, CountryFeature>('#map .country')
       .transition().duration(220)
-      .attr('fill', d => {
-        const entry = sd[d.properties.name];
-        return entry ? refreshed(entry[attr] as number) : cssVar('--no-data');
-      })
+      .attr('fill', d => fillFor(sd[d.properties.name], attr, refreshed))
       .attr('stroke', cssVar('--map-stroke'));
     select('#map .sphere').attr('fill', cssVar('--ocean'));
     select('#map .graticule').attr('stroke', cssVar('--text-tertiary'));
@@ -328,12 +338,13 @@ export function updateMap(overrideScoreData?: MapScores): void {
 
   select('#map')
     .selectAll<SVGPathElement, CountryFeature>('.country')
+    // Cancel any in-flight recolor before starting a new one, so a rapid
+    // sequence (slider drag, mode flips) doesn't queue overlapping
+    // transitions that fight over the same fill/opacity.
+    .interrupt()
     .transition()
     .duration(500)
-    .attr('fill', d => {
-      const entry = data[d.properties.name];
-      return entry ? colorScale(entry[currentAttribute] as number) : cssVar('--no-data');
-    })
+    .attr('fill', d => fillFor(data[d.properties.name], currentAttribute, colorScale))
     .style('opacity', d => countryOpacity(d.properties.name, data[d.properties.name], {
       currentAttribute, filterMin, filterMax, blocSet,
     }));
@@ -351,7 +362,7 @@ export function clearHighlight(): void {
   selectAll('.country').classed('selected', false).attr('stroke-width', 0.3);
 }
 
-export function markComparisonCountries(names: string[] | null | undefined): void {
+export function markComparisonCountries(names: readonly string[] | null | undefined): void {
   selectAll('.country')
     .classed('in-comparison', false)
     .attr('data-comparison-index', null);

--- a/src/map/renderer.ts
+++ b/src/map/renderer.ts
@@ -10,7 +10,7 @@ import 'd3-transition';
 
 import { ATTRIBUTE_LABELS } from '../constants';
 import type { AttributeKey } from '../constants';
-import { getState, setState } from '../state/store';
+import { getState } from '../state/store';
 import type { ScoreData, ScoreEntry } from '../data/loader';
 import type { HistorySnapshot } from '../data/history';
 import { makeColorScale, addLegend } from './legend';
@@ -18,7 +18,8 @@ import type { ColorScale } from './legend';
 import { createTooltip, showTooltip, hideTooltip } from './tooltip';
 import { setupZoom } from './zoom';
 import type { ZoomHandle } from './zoom';
-import { toggleComparison, getColorIndex } from '../comparison/index';
+import { toggleComparison, selectCountry } from '../state/interactions';
+import { getColorIndex } from '../comparison/colorSlots';
 import { cssVar, onThemeChange } from './cssColors';
 
 /** A world-atlas country geometry with its bound name property. */
@@ -244,7 +245,7 @@ export async function generateMap(): Promise<void> {
         toggleComparison(name);
         event.preventDefault();
       } else {
-        setState({ selectedCountry: name });
+        selectCountry(name);
       }
     });
 
@@ -266,7 +267,7 @@ export async function generateMap(): Promise<void> {
     if (Math.hypot(event.clientX - downX, event.clientY - downY) > 6) return;
     const target = event.target as Element | null;
     if (target?.classList?.contains('country')) return;
-    if (getState().selectedCountry) setState({ selectedCountry: null });
+    if (getState().selectedCountry) selectCountry(null);
   });
 
   onThemeChange(() => {

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -1,4 +1,5 @@
 import { getState, setState, on } from '../state/store';
+import { maybeEl } from '../dom';
 import { renderScoreBar, renderAllDots } from './scores';
 import { renderTextSections } from './sections';
 import { renderChangelog } from './changelog';
@@ -111,7 +112,7 @@ function updateDimensionHighlight(): void {
 }
 
 function updateCompareButton(): void {
-  const btn = document.getElementById('compare-btn') as HTMLButtonElement | null;
+  const btn = maybeEl<HTMLButtonElement>('compare-btn');
   if (!btn) return;
   const { selectedCountry, comparisonCountries } = getState();
   if (!selectedCountry) {
@@ -136,7 +137,7 @@ function updateCompareButton(): void {
 }
 
 function updateCiteButton(): void {
-  const btn = document.getElementById('cite-btn') as HTMLButtonElement | null;
+  const btn = maybeEl<HTMLButtonElement>('cite-btn');
   if (!btn) return;
   const { selectedCountry, comparisonCountries } = getState();
   const disabled = !selectedCountry && comparisonCountries.length === 0;
@@ -281,7 +282,7 @@ export function initPanel(): void {
 
   // Copy the full source list as a numbered, paste-ready block —
   // analysts move these into footnotes and research notes.
-  const sourcesCopyBtn = document.getElementById('sources-copy') as HTMLButtonElement | null;
+  const sourcesCopyBtn = maybeEl<HTMLButtonElement>('sources-copy');
   if (sourcesCopyBtn) {
     sourcesCopyBtn.addEventListener('click', async () => {
       const { selectedCountry, regulationData } = getState();

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -235,7 +235,12 @@ function renderPanel(countryName: string): void {
 
 function clearPanel(): void {
   const fallback = document.getElementById('no-selection-message');
-  if (fallback) fallback.hidden = false;
+  // Show the "select a country" fallback only once the onboarding intro
+  // is gone. Until the user has selected their first country the intro
+  // is still mounted (consumeIntro removes it), and stacking both reads
+  // as a contradictory double empty-state — which a bare Esc (deselect
+  // with nothing selected) would otherwise trigger.
+  if (fallback) fallback.hidden = document.getElementById('panel-intro') !== null;
   document.getElementById('panel-content')!.style.display = 'none';
   // Slide the mobile bottom sheet back down (inert on desktop).
   document.body.classList.remove('sheet-open');

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -4,6 +4,7 @@ import { renderTextSections } from './sections';
 import { renderChangelog } from './changelog';
 import { highlightCountry, clearHighlight } from '../map/index';
 import { toggleComparison } from '../state/interactions';
+import { maturityRank } from '../state/selectors';
 import { MAX_COMPARISON } from '../constants';
 import { classifySources, formatSourcesForCopy } from '../data/sources';
 import { writeClipboard } from '../controls/clipboard';
@@ -143,22 +144,14 @@ function updateCiteButton(): void {
   btn.title = disabled ? 'Select a country first' : '';
 }
 
-// Maturity-index rank among countries with a composite score. Ties
-// share a rank (strictly-higher count + 1).
+// Maturity-index rank among countries with a composite score. The ranking is
+// derived once per data load by the memoized selector, not recomputed on every
+// panel render.
 function renderRank(countryName: string): void {
   const el = document.getElementById('maturity-rank');
   if (!el) return;
-  const { scoreData } = getState();
-  const mine = scoreData[countryName]?.averageScore;
-  if (mine == null) {
-    el.textContent = '';
-    return;
-  }
-  const scored = Object.values(scoreData)
-    .map(d => d.averageScore)
-    .filter((v): v is number => v != null);
-  const rank = scored.filter(v => v > mine).length + 1;
-  el.textContent = `Rank ${rank} of ${scored.length}`;
+  const result = maturityRank(countryName);
+  el.textContent = result ? `Rank ${result.rank} of ${result.total}` : '';
 }
 
 function renderPanel(countryName: string): void {

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -3,7 +3,8 @@ import { renderScoreBar, renderAllDots } from './scores';
 import { renderTextSections } from './sections';
 import { renderChangelog } from './changelog';
 import { highlightCountry, clearHighlight } from '../map/index';
-import { toggleComparison, MAX_COMPARISON } from '../comparison/index';
+import { toggleComparison } from '../state/interactions';
+import { MAX_COMPARISON } from '../constants';
 import { classifySources, formatSourcesForCopy } from '../data/sources';
 import { writeClipboard } from '../controls/clipboard';
 
@@ -161,14 +162,15 @@ function renderRank(countryName: string): void {
 }
 
 function renderPanel(countryName: string): void {
-  const { scoreData, regulationData, comparisonViewOpen } = getState();
+  const { scoreData, regulationData, mainView } = getState();
   const score = scoreData[countryName];
   const reg = regulationData[countryName];
+  const comparisonOpen = mainView === 'comparison';
 
   // The full comparison view owns the main area; don't reveal the
   // single-country panel underneath it. While merely staging a set
   // (view closed), the panel stays usable so the user keeps browsing.
-  if (!comparisonViewOpen) {
+  if (!comparisonOpen) {
     const fallback = document.getElementById('no-selection-message');
     if (fallback) fallback.hidden = true;
     document.getElementById('panel-content')!.style.display = '';
@@ -217,7 +219,7 @@ function renderPanel(countryName: string): void {
   // On phones the panel is a bottom sheet layered over the map. Selecting
   // a country slides it up (the transition lives in CSS); on desktop the
   // class is inert. Skip while the full comparison view owns the screen.
-  if (!comparisonViewOpen) {
+  if (!comparisonOpen) {
     // Reset to the top for every fresh country — otherwise, after
     // scrolling one country's sheet/panel, the next selection opens
     // mid-content with the name and score off-screen. renderPanel only
@@ -277,11 +279,11 @@ export function initPanel(): void {
   }
   initSheetDrag();
 
-  // The scatter explorer takes over the map slot; drop the sheet out of
-  // the way when it opens so it doesn't sit on top of the plot. Tapping a
-  // dot re-selects a country, which re-opens the sheet over the scatter.
-  on('scatterOpen', (open) => {
-    if (open) document.body.classList.remove('sheet-open');
+  // An overlay view (scatter or comparison) takes over the map slot; drop the
+  // mobile sheet out of the way when one opens so it doesn't sit on top.
+  // Tapping a dot re-selects a country, which re-opens the sheet over scatter.
+  on('mainView', (view) => {
+    if (view !== 'map') document.body.classList.remove('sheet-open');
   });
 
   // Copy the full source list as a numbered, paste-ready block —

--- a/src/panel/sections.ts
+++ b/src/panel/sections.ts
@@ -1,4 +1,5 @@
 import { PLACEHOLDER_RE } from '../constants';
+import { maybeEl } from '../dom';
 import type { DimensionKey } from '../constants';
 import { normalizeRegulationText } from './normalize';
 import { classifySources } from '../data/sources';
@@ -62,7 +63,7 @@ export function renderTextSections(regData: RegulationEntry | null | undefined):
   sourcesContainer.replaceChildren();
   const sources = classifySources(regData.sources);
 
-  const copyBtn = document.getElementById('sources-copy') as HTMLButtonElement | null;
+  const copyBtn = maybeEl<HTMLButtonElement>('sources-copy');
   if (copyBtn) copyBtn.hidden = sources.length === 0;
 
   if (sources.length > 0) {

--- a/src/scatter/index.ts
+++ b/src/scatter/index.ts
@@ -17,6 +17,7 @@ import { format } from 'd3-format';
 import 'd3-transition';
 
 import { getState, setState, on } from '../state/store';
+import { toggleScatter, showMap } from '../state/interactions';
 import { ATTRIBUTE_LABELS, SCORE_OPTIONS } from '../constants';
 import type { AttributeKey } from '../constants';
 import { makeColorScale } from '../map/legend';
@@ -110,7 +111,7 @@ function createChart(): void {
   // window-resize listener both miss the header-height changes).
   if (typeof ResizeObserver === 'function') {
     const ro = new ResizeObserver(() => {
-      if (getState().scatterOpen) { layout(); updateChart(); }
+      if (getState().mainView === 'scatter') { layout(); updateChart(); }
     });
     ro.observe(document.getElementById('scatter-chart')!);
   }
@@ -268,24 +269,22 @@ export function initScatter(): void {
   populateAxisSelects();
 
   btn.addEventListener('click', () => {
-    const opening = !getState().scatterOpen;
-    // Explorer and the comparison view are mutually exclusive — both
-    // own the main area.
-    if (opening && getState().comparisonViewOpen) setState({ comparisonViewOpen: false });
-    setState({ scatterOpen: opening });
-    // Move focus into the explorer so keyboard users land in the new
-    // view (and back to the trigger when it closes). Only on explicit
-    // toggles — not on load / URL restore, which call setVisible directly.
-    if (opening) closeBtn.focus();
+    // The FSM makes scatter and comparison mutually exclusive for free —
+    // switching to scatter simply leaves whatever view was active.
+    toggleScatter();
+    // Move focus into the explorer so keyboard users land in the new view
+    // (and back to the trigger when it closes). Only on explicit toggles —
+    // not on load / URL restore, which call setVisible directly.
+    if (getState().mainView === 'scatter') closeBtn.focus();
   });
   closeBtn.addEventListener('click', () => {
-    setState({ scatterOpen: false });
+    showMap();
     btn.focus();
   });
 
-  on('scatterOpen', setVisible);
+  on('mainView', (view) => setVisible(view === 'scatter'));
 
-  const refreshIfOpen = () => { if (getState().scatterOpen) updateChart(); };
+  const refreshIfOpen = () => { if (getState().mainView === 'scatter') updateChart(); };
   on('scatterX', () => {
     const sel = document.getElementById('scatter-x') as HTMLSelectElement;
     sel.value = getState().scatterX;
@@ -304,5 +303,5 @@ export function initScatter(): void {
   on('selectedBloc', refreshIfOpen);
   onThemeChange(refreshIfOpen);
 
-  setVisible(getState().scatterOpen);
+  setVisible(getState().mainView === 'scatter');
 }

--- a/src/scatter/index.ts
+++ b/src/scatter/index.ts
@@ -9,6 +9,7 @@
 // silently mix vintages).
 
 import { select } from 'd3-selection';
+import { el } from '../dom';
 import type { Selection } from 'd3-selection';
 import { scaleLinear } from 'd3-scale';
 import type { ScaleLinear } from 'd3-scale';
@@ -63,7 +64,7 @@ let xScale: ScaleLinear<number, number>, yScale: ScaleLinear<number, number>;
 function populateAxisSelects(): void {
   const { scatterX, scatterY } = getState();
   for (const [id, current] of [['scatter-x', scatterX], ['scatter-y', scatterY]]) {
-    const sel = document.getElementById(id) as HTMLSelectElement;
+    const sel = el<HTMLSelectElement>(id);
     for (const dim of AXIS_DIMENSIONS) {
       const opt = document.createElement('option');
       opt.value = dim.value;
@@ -286,12 +287,12 @@ export function initScatter(): void {
 
   const refreshIfOpen = () => { if (getState().mainView === 'scatter') updateChart(); };
   on('scatterX', () => {
-    const sel = document.getElementById('scatter-x') as HTMLSelectElement;
+    const sel = el<HTMLSelectElement>('scatter-x');
     sel.value = getState().scatterX;
     refreshIfOpen();
   });
   on('scatterY', () => {
-    const sel = document.getElementById('scatter-y') as HTMLSelectElement;
+    const sel = el<HTMLSelectElement>('scatter-y');
     sel.value = getState().scatterY;
     refreshIfOpen();
   });

--- a/src/state/interactions.ts
+++ b/src/state/interactions.ts
@@ -1,0 +1,119 @@
+// Interaction orchestrator — the single home for state transitions that carry
+// an invariant. This is the frontend analogue of the backend's PipelineService:
+// modules dispatch named intents instead of poking `setState` with rules baked
+// in at the call site, so cross-cutting behaviour ("opening scatter closes
+// comparison", "a comparison needs ≥2 countries", "Esc backs out one layer")
+// lives in exactly one place.
+//
+// It depends only on the store, the constants, and the colour-slot leaf — never
+// on a feature module — so it introduces no import cycles. Feature modules
+// subscribe to the resulting store changes as usual.
+
+import { getState, setState } from './store';
+import { MAX_COMPARISON } from '../constants';
+import type { MainView } from '../constants';
+import { syncColorSlots } from '../comparison/colorSlots';
+
+// -- selection ---------------------------------------------------------------
+
+export function selectCountry(name: string | null): void {
+  setState({ selectedCountry: name });
+}
+
+/** Arrow-key navigation through the sorted country list, wrapping at the ends. */
+export function stepCountry(delta: 1 | -1): void {
+  const { sortedCountryNames, selectedCountry } = getState();
+  if (sortedCountryNames.length === 0) return;
+  const current = selectedCountry ? sortedCountryNames.indexOf(selectedCountry) : -1;
+  const n = sortedCountryNames.length;
+  // From no selection, ArrowRight starts at the first country, ArrowLeft at the last.
+  const next = current === -1
+    ? (delta === 1 ? 0 : n - 1)
+    : (current + delta + n) % n;
+  selectCountry(sortedCountryNames[next]);
+}
+
+// -- comparison membership ---------------------------------------------------
+
+// The single writer for the comparison set. Assigns colour slots *before*
+// committing so every subscriber that reads a slot on this change sees a
+// fully-assigned map (removing the old cross-module ordering dependency).
+function commitComparison(names: readonly string[]): void {
+  syncColorSlots(names);
+  setState({ comparisonCountries: names });
+}
+
+export function addToComparison(name: string | null): void {
+  if (!name) return;
+  const { comparisonCountries } = getState();
+  if (comparisonCountries.includes(name)) return;
+  if (comparisonCountries.length >= MAX_COMPARISON) return;
+  commitComparison([...comparisonCountries, name]);
+}
+
+export function removeFromComparison(name: string): void {
+  const { comparisonCountries } = getState();
+  if (!comparisonCountries.includes(name)) return;
+  commitComparison(comparisonCountries.filter(c => c !== name));
+}
+
+export function toggleComparison(name: string): void {
+  const { comparisonCountries } = getState();
+  if (comparisonCountries.includes(name)) removeFromComparison(name);
+  else addToComparison(name);
+}
+
+export function clearComparison(): void {
+  commitComparison([]);
+  if (getState().mainView === 'comparison') showMap();
+}
+
+/**
+ * Restore a comparison from a shared link: commit the set and open the full
+ * view iff it's large enough. Used by URL / deep-link application.
+ */
+export function restoreComparison(names: readonly string[]): void {
+  commitComparison(names);
+  setMainView(names.length >= 2 ? 'comparison' : 'map');
+}
+
+// -- main-area view (the FSM's single writer) --------------------------------
+
+/**
+ * The only place `mainView` is written. Because it's a single field, setting
+ * one view implicitly leaves the others — no explicit "close the other overlay"
+ * dance. Guards the one real invariant: the comparison view needs ≥2 countries.
+ */
+export function setMainView(view: MainView): void {
+  if (view === 'comparison' && getState().comparisonCountries.length < 2) return;
+  setState({ mainView: view });
+}
+
+export function showMap(): void {
+  setMainView('map');
+}
+
+export function openScatter(): void {
+  setMainView('scatter');
+}
+
+export function toggleScatter(): void {
+  setMainView(getState().mainView === 'scatter' ? 'map' : 'scatter');
+}
+
+export function openComparison(): void {
+  setMainView('comparison');
+}
+
+/**
+ * Escape's outermost layer: if an overlay owns the main area, back out to the
+ * map and report that we consumed the key. Returns false when already on the
+ * map, so the caller can handle the inner layers (dropdowns, deselect).
+ */
+export function escapeMainView(): boolean {
+  if (getState().mainView !== 'map') {
+    showMap();
+    return true;
+  }
+  return false;
+}

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -1,0 +1,48 @@
+// Derived state — computed views over the store, memoized so a derivation
+// isn't rebuilt on every render. This is the read-side counterpart to the
+// interactions orchestrator (the write side): modules ask a selector for a
+// derived value instead of recomputing it inline (which the panel used to do
+// for the maturity ranking on every single country selection).
+//
+// Memoization keys on the source object's reference. The score data is
+// replaced wholesale on load and never mutated in place (the store enforces
+// this), so reference identity is a sound cache key.
+
+import { getState } from './store';
+import type { ScoreData } from '../data/loader';
+
+export interface RankResult {
+  rank: number;
+  total: number;
+}
+
+let rankCache: { data: ScoreData; ranks: Map<string, number>; total: number } | null = null;
+
+function rankTable(data: ScoreData) {
+  if (rankCache && rankCache.data === data) return rankCache;
+
+  const values = Object.values(data)
+    .map(d => d.averageScore)
+    .filter((v): v is number => v != null);
+  // Descending sort; a value's rank is the position of its first occurrence,
+  // so ties share a rank (equivalent to "strictly-greater count + 1").
+  const sortedDesc = [...values].sort((a, b) => b - a);
+  const rankByValue = new Map<number, number>();
+  sortedDesc.forEach((v, i) => { if (!rankByValue.has(v)) rankByValue.set(v, i + 1); });
+
+  const ranks = new Map<string, number>();
+  for (const [name, entry] of Object.entries(data)) {
+    if (entry.averageScore != null) ranks.set(name, rankByValue.get(entry.averageScore)!);
+  }
+
+  rankCache = { data, ranks, total: values.length };
+  return rankCache;
+}
+
+/** Maturity-index rank of a country among those with a composite score (ties
+ *  share a rank), or null when the country has no score. */
+export function maturityRank(country: string): RankResult | null {
+  const table = rankTable(getState().scoreData);
+  const rank = table.ranks.get(country);
+  return rank == null ? null : { rank, total: table.total };
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -11,11 +11,14 @@ export interface AppState {
   filterMin: number;
   filterMax: number;
   selectedCountry: string | null;
-  sortedCountryNames: string[];
+  // Read-only arrays: the store owns these; consumers replace them via
+  // setState (always with a fresh array), never mutate in place. The
+  // `readonly` modifier makes an accidental `.push()` a compile error.
+  sortedCountryNames: readonly string[];
   // The staged comparison set (0-4). Membership is separate from
   // whether the full comparison VIEW is open (comparisonViewOpen) —
   // the user builds a set, then opens the comparison deliberately.
-  comparisonCountries: string[];
+  comparisonCountries: readonly string[];
   comparisonViewOpen: boolean;
   // null = "latest" (use current scoreData as-is); otherwise an ISO date
   // string (YYYY-MM-DD) present in history.json. The timeline slider
@@ -60,15 +63,35 @@ const state: AppState = {
 type AnyListener = (value: unknown) => void;
 const listeners = new Map<keyof AppState, Set<AnyListener>>();
 
-export function getState(): AppState {
+/**
+ * The state is exposed to consumers as deeply read-only. All mutation
+ * flows through setState(); getState() is a window, not a handle. This
+ * is a compile-time contract (zero runtime cost) — it turns an
+ * accidental `getState().comparisonCountries.push(...)`, which would
+ * silently bypass every listener, into a type error.
+ */
+export function getState(): Readonly<AppState> {
   return state;
 }
 
+/**
+ * Merge a patch into the state and notify listeners — but only for keys
+ * whose value actually changed. Skipping no-op writes prevents redundant
+ * re-renders: several call sites write multiple keys at once (e.g. both
+ * filter sliders) even when only one moved, and a bare deselect (Esc)
+ * writes selectedCountry:null when it is already null. Comparison is by
+ * reference, which is correct here because the store never mutates a
+ * non-primitive in place — a changed array/object is always a new one.
+ */
 export function setState(patch: Partial<AppState>): void {
-  Object.assign(state, patch);
+  const changed: (keyof AppState)[] = [];
   for (const key of Object.keys(patch) as (keyof AppState)[]) {
-    emit(key, state[key]);
+    if (state[key] !== patch[key]) {
+      (state as Record<keyof AppState, unknown>)[key] = patch[key];
+      changed.push(key);
+    }
   }
+  for (const key of changed) emit(key, state[key]);
 }
 
 /** Subscribe to changes of one state key. Returns an unsubscribe function. */

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -61,8 +61,13 @@ const state: AppState = {
   scatterY: 'regulationStatus',
 };
 
-type AnyListener = (value: unknown) => void;
-const listeners = new Map<keyof AppState, Set<AnyListener>>();
+/** A listener for one state key `K`, receiving that key's value type. */
+type Listener<K extends keyof AppState> = (value: AppState[K]) => void;
+
+// The Set erases `K` — a heterogeneous "key → Set<Listener<that key>>" map
+// isn't expressible in TS — but on()/emit() reassert it at the boundary, so
+// every public caller stays fully typed.
+const listeners = new Map<keyof AppState, Set<Listener<keyof AppState>>>();
 
 /**
  * The state is exposed to consumers as deeply read-only. All mutation
@@ -96,19 +101,15 @@ export function setState(patch: Partial<AppState>): void {
 }
 
 /** Subscribe to changes of one state key. Returns an unsubscribe function. */
-export function on<K extends keyof AppState>(
-  event: K,
-  handler: (value: AppState[K]) => void
-): () => void {
-  if (!listeners.has(event)) listeners.set(event, new Set());
-  const set = listeners.get(event) as Set<AnyListener>;
-  set.add(handler as AnyListener);
-  return () => set.delete(handler as AnyListener);
+export function on<K extends keyof AppState>(event: K, handler: Listener<K>): () => void {
+  let set = listeners.get(event);
+  if (!set) { set = new Set(); listeners.set(event, set); }
+  set.add(handler as Listener<keyof AppState>);
+  return () => { set.delete(handler as Listener<keyof AppState>); };
 }
 
-function emit(event: keyof AppState, value: unknown): void {
+function emit<K extends keyof AppState>(event: K, value: AppState[K]): void {
   const handlers = listeners.get(event);
-  if (handlers) {
-    for (const fn of handlers) fn(value);
-  }
+  if (!handlers) return;
+  for (const fn of handlers) (fn as Listener<K>)(value);
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,4 +1,4 @@
-import type { AttributeKey } from '../constants';
+import type { AttributeKey, MainView } from '../constants';
 import type { ScoreData, RegulationData } from '../data/loader';
 import type { HistoryData } from '../data/history';
 import type { BlocsData } from '../data/blocs';
@@ -15,11 +15,10 @@ export interface AppState {
   // setState (always with a fresh array), never mutate in place. The
   // `readonly` modifier makes an accidental `.push()` a compile error.
   sortedCountryNames: readonly string[];
-  // The staged comparison set (0-4). Membership is separate from
-  // whether the full comparison VIEW is open (comparisonViewOpen) —
-  // the user builds a set, then opens the comparison deliberately.
+  // The staged comparison set (0-4). Membership is separate from whether the
+  // full comparison VIEW is showing (mainView === 'comparison') — the user
+  // builds a set, then opens the comparison deliberately.
   comparisonCountries: readonly string[];
-  comparisonViewOpen: boolean;
   // null = "latest" (use current scoreData as-is); otherwise an ISO date
   // string (YYYY-MM-DD) present in history.json. The timeline slider
   // writes this; the map subscribes and re-renders historic scores.
@@ -34,8 +33,11 @@ export interface AppState {
   // Parsed subscores.json (methodology v2 sub-indicator audit trail) —
   // loaded async; null until then / on failure.
   subscores: SubscoresData | null;
-  // Scatter plot ("dimension explorer") panel state.
-  scatterOpen: boolean;
+  // Which surface owns the main area: the map, the scatter explorer, or the
+  // full comparison view. Exactly one at a time (see MainView).
+  mainView: MainView;
+  // Scatter plot ("dimension explorer") axis selection. Persist across
+  // open/close so reopening restores the last pairing.
   scatterX: AttributeKey;
   scatterY: AttributeKey;
 }
@@ -49,13 +51,12 @@ const state: AppState = {
   selectedCountry: null,
   sortedCountryNames: [],
   comparisonCountries: [],
-  comparisonViewOpen: false,
   timelineDate: null,
   history: null,
   selectedBloc: null,
   blocsData: null,
   subscores: null,
-  scatterOpen: false,
+  mainView: 'map',
   scatterX: 'enforcementLevel',
   scatterY: 'regulationStatus',
 };

--- a/src/styles/_footer.css
+++ b/src/styles/_footer.css
@@ -16,12 +16,14 @@ footer p {
 
 footer a {
   color: var(--accent);
-  text-decoration: none;
+  /* Underlined by default: these links sit inline within paragraphs, so
+     colour alone can't distinguish them (WCAG 1.4.1). */
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-thickness: from-font;
   transition: color 0.15s;
 }
 
 footer a:hover {
   color: var(--accent-hover);
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }

--- a/src/styles/_panel.css
+++ b/src/styles/_panel.css
@@ -104,6 +104,9 @@
   align-items: center;
   gap: 10px;
   margin-bottom: 6px;
+  /* Long names (e.g. "Saint Vincent and the Grenadines") wrap the badge
+     to the next line instead of overflowing the panel or squashing it. */
+  flex-wrap: wrap;
 }
 
 #country-name {
@@ -112,6 +115,8 @@
   font-weight: 500;
   color: var(--text-primary);
   letter-spacing: -0.005em;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .data-freshness {
@@ -355,6 +360,7 @@
   background: transparent;
   color: var(--text-tertiary);
   border: 1px solid transparent;
+  flex-shrink: 0;
 }
 
 .confidence-badge::before {

--- a/src/styles/_scatter.css
+++ b/src/styles/_scatter.css
@@ -94,6 +94,37 @@ body.view-scatter #timeline-strip {
   border-color: var(--accent);
 }
 
+/* Color key: dots are tinted by maturity index (same scale as the map's
+   choropleth), which is otherwise unexplained in this view. Pushed to
+   the right of the axis selects. */
+.scatter-colorkey {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+}
+
+.scatter-colorkey-ends {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.6rem;
+}
+
+.scatter-colorkey-bar {
+  width: 60px;
+  height: 8px;
+  border-radius: 2px;
+  /* CSS custom props so the swatch restyles with the theme for free. */
+  background: linear-gradient(90deg, var(--score-low), var(--score-high));
+}
+
+@media (max-width: 768px), (max-height: 500px) and (pointer: coarse) {
+  .scatter-colorkey { margin-left: 0; }
+}
+
 #scatter-chart {
   flex: 1;
   min-height: 0;

--- a/src/styles/_tokens.css
+++ b/src/styles/_tokens.css
@@ -40,7 +40,9 @@
 
   --text-primary:    oklch(92% 0.012 var(--brand-hue));
   --text-secondary:  oklch(72% 0.014 var(--brand-hue));
-  --text-tertiary:   oklch(58% 0.014 var(--brand-hue)); /* WCAG AA on --bg */
+  /* 62% clears WCAG AA (~5:1) against --surface, where most tertiary text
+     actually sits (header, footer, timeline). 58% only reached 4.3:1 there. */
+  --text-tertiary:   oklch(62% 0.014 var(--brand-hue));
 
   --accent:          oklch(76% 0.13 var(--brand-hue));
   --accent-hover:    oklch(82% 0.13 var(--brand-hue));

--- a/src/styles/_tokens.css
+++ b/src/styles/_tokens.css
@@ -89,7 +89,10 @@
 
     --text-primary:    oklch(20% 0.013 80);
     --text-secondary:  oklch(42% 0.014 80);
-    --text-tertiary:   oklch(58% 0.014 80);
+    /* 52% (≈5.2:1 on --bg) clears WCAG AA for normal text on the light
+       background; the old 58% only reached ~4.05:1. Still the lightest
+       muted tier, so the typographic hierarchy is preserved. */
+    --text-tertiary:   oklch(52% 0.014 80);
 
     --accent:          oklch(48% 0.16 60);
     --accent-hover:    oklch(42% 0.17 60);
@@ -121,7 +124,8 @@
 
   --text-primary:    oklch(20% 0.013 80);
   --text-secondary:  oklch(42% 0.014 80);
-  --text-tertiary:   oklch(58% 0.014 80);
+  /* See the media-query block above: 52% clears WCAG AA on --bg. */
+  --text-tertiary:   oklch(52% 0.014 80);
 
   --accent:          oklch(48% 0.16 60);
   --accent-hover:    oklch(42% 0.17 60);

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// Smoke coverage for the paths unit tests can't reach: the map actually
+// renders, a country selects into the panel, and the built page has no
+// serious/critical accessibility violations in either theme. This is the
+// net that catches a regression in the choropleth render, the search →
+// select flow, or a contrast/ARIA breakage before it ships.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  // The choropleth is drawn client-side after the CSV + topojson load.
+  await page.waitForSelector('#map svg path.country', { timeout: 15_000 });
+});
+
+test('map renders every country as a choropleth path', async ({ page }) => {
+  const paths = page.locator('#map svg path.country');
+  // world-atlas 110m has ~170+ country geometries; assert the map isn't empty.
+  expect(await paths.count()).toBeGreaterThan(150);
+  await expect(page.locator('#map svg')).toHaveAttribute('role', 'img');
+});
+
+test('search → Enter selects a country into the panel', async ({ page }) => {
+  await page.fill('#country-search', 'Germany');
+  await page.waitForSelector('#search-suggestions li[role="option"]');
+  // Enter with no arrow-highlight must commit the top match (regression guard).
+  await page.keyboard.press('Enter');
+  await expect(page.locator('#country-name')).toHaveText(/Germany/);
+  await expect(page.locator('#panel-content')).toBeVisible();
+});
+
+test('Escape before any selection does not stack two empty states', async ({ page }) => {
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#panel-intro')).toBeVisible();
+  // The "select a country" fallback must stay hidden while the intro shows.
+  await expect(page.locator('#no-selection-message')).toBeHidden();
+});
+
+for (const theme of ['light', 'dark'] as const) {
+  test(`no serious/critical a11y violations (${theme})`, async ({ page }) => {
+    await page.emulateMedia({ colorScheme: theme });
+    await page.evaluate(t => document.documentElement.setAttribute('data-theme', t), theme);
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa'])
+      .analyze();
+    const serious = results.violations.filter(
+      v => v.impact === 'serious' || v.impact === 'critical'
+    );
+    expect(serious, JSON.stringify(serious.map(v => ({ id: v.id, nodes: v.nodes.length })), null, 2))
+      .toEqual([]);
+  });
+}

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+// Exercises the mainView FSM end to end: exactly one overlay owns the main
+// area, switching to one leaves the other, and Escape backs out to the map.
+// These are the paths the interactions-orchestrator refactor touched.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('#map svg path.country', { timeout: 15_000 });
+});
+
+async function addToComparison(page, name: string) {
+  await page.fill('#country-search', name);
+  await page.waitForSelector('#search-suggestions li[role="option"]');
+  await page.keyboard.press('Enter');
+  await page.click('#compare-btn');
+}
+
+test('scatter opens and Escape returns to the map', async ({ page }) => {
+  await page.click('#scatter-btn');
+  await expect(page.locator('body')).toHaveClass(/view-scatter/);
+  await expect(page.locator('#scatter-container')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('body')).not.toHaveClass(/view-scatter/);
+});
+
+test('opening comparison leaves scatter — never both at once', async ({ page }) => {
+  await page.click('#scatter-btn');
+  await expect(page.locator('body')).toHaveClass(/view-scatter/);
+
+  await addToComparison(page, 'Germany');
+  await addToComparison(page, 'France');
+  await page.click('#tray-view-btn');
+
+  // The FSM guarantees mutual exclusion: comparison is on, scatter is off.
+  await expect(page.locator('body')).toHaveClass(/view-compare/);
+  await expect(page.locator('body')).not.toHaveClass(/view-scatter/);
+  await expect(page.locator('#comparison-panel')).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('body')).not.toHaveClass(/view-compare/);
+});
+
+test('comparison colours are stable when a middle country is removed', async ({ page }) => {
+  await addToComparison(page, 'Germany');
+  await addToComparison(page, 'France');
+  await addToComparison(page, 'Japan');
+  await page.click('#tray-view-btn');
+
+  const colOf = async (name: string) =>
+    page.locator(`#comparison-table [data-country="${name}"], #comparison-table th`, { hasText: name })
+      .first().evaluate(el => getComputedStyle(el as HTMLElement).color);
+
+  const japanBefore = await colOf('Japan');
+  // Remove the middle country (France) via its chip.
+  await page.locator('#comparison-chips').getByRole('button', { name: /France/ }).click();
+  const japanAfter = await colOf('Japan');
+  // Japan keeps its colour slot — removal must not reshuffle the others.
+  expect(japanAfter).toBe(japanBefore);
+});

--- a/tests/e2e/views.spec.ts
+++ b/tests/e2e/views.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 // Exercises the mainView FSM end to end: exactly one overlay owns the main
 // area, switching to one leaves the other, and Escape backs out to the map.
@@ -9,7 +10,7 @@ test.beforeEach(async ({ page }) => {
   await page.waitForSelector('#map svg path.country', { timeout: 15_000 });
 });
 
-async function addToComparison(page, name: string) {
+async function addToComparison(page: Page, name: string) {
   await page.fill('#country-search', name);
   await page.waitForSelector('#search-suggestions li[role="option"]');
   await page.keyboard.press('Enter');

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { loadScores } from '../src/data/loader';
+
+// loadScores parses scores.csv via d3-fetch (global fetch). Stub fetch with a
+// CSV body to exercise the validation boundary: non-numeric and out-of-range
+// cells must become null (not NaN), and a blank country row must be dropped.
+
+const HEADER =
+  'Country,Regulation Status,Policy Lever,Governance Type,Actor Involvement,Average Score,Enforcement Level,Last Updated,Data Version';
+
+function stubCsv(body) {
+  globalThis.fetch = () => Promise.resolve({ ok: true, text: () => Promise.resolve(body) });
+}
+
+afterEach(() => { delete globalThis.fetch; });
+
+describe('loadScores validation', () => {
+  it('parses a well-formed row', async () => {
+    stubCsv(`${HEADER}\nGermany,4,3.5,2,3,3.5,4,2026-06-11,2`);
+    const data = await loadScores();
+    expect(data.Germany.regulationStatus).toBe(4);
+    expect(data.Germany.policyLever).toBe(3.5);
+    expect(data.Germany.enforcementLevel).toBe(4);
+    expect(data.Germany.dataVersion).toBe(2);
+  });
+
+  it('coerces a non-numeric score to null, never NaN', async () => {
+    stubCsv(`${HEADER}\nAtlantis,banana,3,2,3,3,4,2026-06-11,1`);
+    const { Atlantis } = await loadScores();
+    expect(Atlantis.regulationStatus).toBeNull();
+    expect(Number.isNaN(Atlantis.regulationStatus)).toBe(false);
+  });
+
+  it('rejects out-of-range scores (>5 or <1) as null', async () => {
+    stubCsv(`${HEADER}\nOz,9,0,2,3,3,4,2026-06-11,1`);
+    const { Oz } = await loadScores();
+    expect(Oz.regulationStatus).toBeNull(); // 9 out of [1,5]
+    expect(Oz.policyLever).toBeNull();      // 0 out of [1,5]
+    expect(Oz.governanceType).toBe(2);
+  });
+
+  it('treats an empty score cell as null', async () => {
+    stubCsv(`${HEADER}\nNod,,3,2,3,3,4,2026-06-11,1`);
+    const { Nod } = await loadScores();
+    expect(Nod.regulationStatus).toBeNull();
+  });
+
+  it('drops a row with a blank country name', async () => {
+    stubCsv(`${HEADER}\n,4,3,2,3,3,4,2026-06-11,1\nRealPlace,4,3,2,3,3,4,2026-06-11,1`);
+    const data = await loadScores();
+    expect(Object.keys(data)).toEqual(['RealPlace']);
+  });
+
+  it('defaults a missing/garbled Data Version to 1', async () => {
+    stubCsv(`${HEADER}\nEmpire,4,3,2,3,3,4,2026-06-11,`);
+    const { Empire } = await loadScores();
+    expect(Empire.dataVersion).toBe(1);
+  });
+});

--- a/tests/pipeline/test_hardening.py
+++ b/tests/pipeline/test_hardening.py
@@ -1,0 +1,135 @@
+"""Regression tests for the pipeline hardening pass.
+
+Covers the behaviors added in the senior-review fixes: validate-time
+confidence capping, the sync wall-clock budget, injectable batch grace,
+settings-root validation, alias-map immutability, durable/atomic writes, and
+numeric normalization of Data Version on load.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+from conftest import full_result
+from regulation_pipeline.batch import CANCEL_GRACE_SECONDS, BatchRunner
+from regulation_pipeline.config import Settings
+from regulation_pipeline.errors import FatalAPIError
+from regulation_pipeline.models import ResearchResult
+from regulation_pipeline.names import CountryNames
+from regulation_pipeline.repository import Dataset, _write_text
+from regulation_pipeline.strategies import SyncStrategy
+
+TODAY = date(2026, 6, 11)
+
+
+class StubResearchClient:
+    def __init__(self, results: dict):
+        self.results = results
+
+    def research(self, country, existing, *, use_search):
+        return self.results.get(country)
+
+    def request_params(self, country, existing, *, use_search):
+        return {"country": country}
+
+
+class TestConfidenceValidator:
+    def test_field_downgraded_at_validation_time(self):
+        # The rule is now enforced in the model, not only on write: the
+        # confidence FIELD itself is capped, so the in-memory object never
+        # advertises a confidence its (missing) sources can't support.
+        model = ResearchResult.model_validate(full_result(sources="", confidence="high"))
+        assert model.confidence == "low"
+        assert model.effective_confidence() == "low"
+
+    def test_whitespace_only_sources_downgrade(self):
+        model = ResearchResult.model_validate(full_result(sources="   \n ", confidence="medium"))
+        assert model.confidence == "low"
+
+    def test_sourced_confidence_preserved(self):
+        model = ResearchResult.model_validate(full_result(confidence="high"))
+        assert model.confidence == "high"
+
+
+class TestSyncWallClock:
+    def test_aborts_when_budget_exceeded(self):
+        # Fake monotonic clock: start=0, first country at 10s (under the 60s
+        # budget), second country's pre-check at 100s (over budget → abort).
+        ticks = iter([0.0, 10.0, 100.0])
+        client = StubResearchClient({"A": full_result(), "B": full_result()})
+        strat = SyncStrategy(
+            client, lambda c: False, sleep=lambda s: None,
+            max_wall_seconds=60, clock=lambda: next(ticks),
+        )
+        gen = strat.research(["A", "B"], {})
+        assert gen.__next__()[0] == "A"      # first country under budget
+        with pytest.raises(FatalAPIError):
+            gen.__next__()                    # second: clock now past budget
+
+    def test_unbounded_by_default(self):
+        client = StubResearchClient({"A": full_result()})
+        out = list(SyncStrategy(client, lambda c: False, sleep=lambda s: None).research(["A"], {}))
+        assert isinstance(out[0][1], ResearchResult)
+
+
+class TestBatchGraceInjectable:
+    def test_defaults_to_module_constant(self):
+        runner = BatchRunner(client=object(), sleep=lambda s: None)
+        assert runner._cancel_grace_seconds == CANCEL_GRACE_SECONDS
+
+    def test_override_is_respected(self):
+        runner = BatchRunner(client=object(), cancel_grace_seconds=42, sleep=lambda s: None)
+        assert runner._cancel_grace_seconds == 42
+
+
+class TestSettingsValidation:
+    def test_valid_root_returns_self(self, tmp_path):
+        assert Settings(root=tmp_path).validate().root == tmp_path
+
+    def test_missing_root_raises(self, tmp_path):
+        with pytest.raises(NotADirectoryError):
+            Settings(root=tmp_path / "does-not-exist").validate()
+
+    def test_file_root_raises(self, tmp_path):
+        f = tmp_path / "afile"
+        f.write_text("x")
+        with pytest.raises(NotADirectoryError):
+            Settings(root=f).validate()
+
+
+class TestNamesImmutable:
+    def test_mutating_source_dict_does_not_leak(self):
+        src = {"Czech Republic": "Czechia"}
+        names = CountryNames(src)
+        src["Czech Republic"] = "WRONG"        # mutate the caller's dict
+        src["Germany"] = "Deutschland"
+        assert names.canonical("Czech Republic") == "Czechia"
+        assert names.canonical("Germany") == "Germany"
+
+    def test_internal_table_is_read_only(self):
+        names = CountryNames({"a": "b"})
+        with pytest.raises(TypeError):
+            names._aliases["a"] = "c"          # MappingProxyType rejects writes
+
+
+class TestDurableWrite:
+    def test_atomic_write_roundtrips_and_leaves_no_tmp(self, tmp_path):
+        target = tmp_path / "out.csv"
+        _write_text(target, "hello,world\n")
+        assert target.read_text(encoding="utf-8") == "hello,world\n"
+        assert not (tmp_path / "out.csv.tmp").exists()
+
+    def test_data_version_loaded_as_int(self, tmp_path):
+        scores = tmp_path / "public" / "scores.csv"
+        scores.parent.mkdir(parents=True)
+        header = ",".join([
+            "Country", "Regulation Status", "Policy Lever", "Governance Type",
+            "Actor Involvement", "Average Score", "Enforcement Level",
+            "Last Updated", "Data Version",
+        ])
+        scores.write_text(f"{header}\nGermany,4,3,2,3,3.67,4,2026-06-11,3\n", encoding="utf-8")
+        ds = Dataset.load(Settings(root=tmp_path), CountryNames({}))
+        assert ds.scores_row("Germany")["Data Version"] == 3
+        assert isinstance(ds.scores_row("Germany")["Data Version"], int)

--- a/tests/selectors.test.js
+++ b/tests/selectors.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { setState } from '../src/state/store';
+import { maturityRank } from '../src/state/selectors';
+
+// The ranking is memoized by scoreData reference; each test installs its own
+// fresh scoreData object, which invalidates the cache.
+
+function scores(map) {
+  const data = {};
+  for (const [name, averageScore] of Object.entries(map)) {
+    data[name] = { country: name, averageScore };
+  }
+  return data;
+}
+
+describe('maturityRank selector', () => {
+  it('ranks by descending maturity, counting only scored countries', () => {
+    setState({ scoreData: scores({ A: 5, B: 3, C: 1 }) });
+    expect(maturityRank('A')).toEqual({ rank: 1, total: 3 });
+    expect(maturityRank('B')).toEqual({ rank: 2, total: 3 });
+    expect(maturityRank('C')).toEqual({ rank: 3, total: 3 });
+  });
+
+  it('shares a rank for ties (strictly-higher count + 1)', () => {
+    setState({ scoreData: scores({ A: 5, B: 4, C: 4, D: 2 }) });
+    expect(maturityRank('A').rank).toBe(1);
+    expect(maturityRank('B')).toEqual({ rank: 2, total: 4 });
+    expect(maturityRank('C')).toEqual({ rank: 2, total: 4 }); // tie with B
+    expect(maturityRank('D')).toEqual({ rank: 4, total: 4 }); // 3 strictly higher
+  });
+
+  it('returns null for an unscored or unknown country', () => {
+    setState({ scoreData: scores({ A: 5, Blank: null }) });
+    expect(maturityRank('Blank')).toBeNull();
+    expect(maturityRank('Nowhere')).toBeNull();
+  });
+});

--- a/tests/store-emit.test.js
+++ b/tests/store-emit.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { setState, on } from '../src/state/store';
+
+// Focused coverage for the emit-on-change guard: a no-op write must not
+// notify listeners (it used to fan out redundant re-renders — a bare Esc
+// re-writing selectedCountry:null, or writing both filter sliders when only
+// one moved).
+
+describe('store: emit only on real change', () => {
+  it('does not emit when the value is unchanged', () => {
+    setState({ filterMax: 5 });
+    let calls = 0;
+    on('filterMax', () => calls++);
+    setState({ filterMax: 5 }); // same value → no emit
+    setState({ filterMax: 5 });
+    expect(calls).toBe(0);
+    setState({ filterMax: 3 }); // real change → emit
+    expect(calls).toBe(1);
+  });
+
+  it('emits only the changed keys in a multi-key patch', () => {
+    setState({ filterMin: 1, filterMax: 4 });
+    const changed = [];
+    on('filterMin', () => changed.push('min'));
+    on('filterMax', () => changed.push('max'));
+    // Only filterMin actually differs from current state.
+    setState({ filterMin: 2, filterMax: 4 });
+    expect(changed).toEqual(['min']);
+  });
+
+  it('re-emits when a new array of equal contents is written (reference change)', () => {
+    setState({ comparisonCountries: [] });
+    let calls = 0;
+    on('comparisonCountries', () => calls++);
+    setState({ comparisonCountries: ['Chile'] });
+    setState({ comparisonCountries: ['Chile'] }); // new array instance → emits
+    expect(calls).toBe(2);
+  });
+});


### PR DESCRIPTION
A critical senior-level pass over the app — reported first, then implemented in small reviewed commits (9 total). Everything is green: **lint, typecheck, 79 unit tests, 8 Playwright e2e (incl. axe a11y), 106 pytest, build**, and `madge --circular src/` reports zero cycles.

## 1 · Desktop UX & accessibility
- **WCAG AA contrast**: light-theme `--text-tertiary` was 4.05:1 (panel labels, legend, footer, timeline) → **oklch(52%) ≈ 5.2:1**. The new axe gate then caught two more the `--bg`-only measurement had understated on the real `--surface`: dark tertiary (4.3:1 → 62% ≈ 5:1) and footer links relying on colour alone (WCAG 1.4.1) → underlined.
- **Search**: `Enter` now commits the top match when nothing is arrow-highlighted (was a dead end); added an aria-live status region announcing result counts / no-results.
- **Panel**: a bare `Esc` before any selection no longer stacks the onboarding intro *and* the "select a country" fallback.
- **Cite popover**: `Esc` restores focus to the Cite button and no longer also deselects the country; citation permalinks omit the `theme` param.
- **Scatter**: added a themed colour key (dots are tinted by maturity index). Long country names wrap; filter Min/Max sliders get real `<label for>`.

## 2 · State store, data boundary & rendering
- `setState` emits only on real change; `getState()` is deeply read-only (mutation is a compile error).
- CSV loader validates scores to finite `[1,5]` or `null` (no more `NaN` leaking into the colour scale/filter math); blank rows dropped.
- Renderer resolves fills through one null/NaN guard; map recolors are rAF-coalesced and interrupt in-flight transitions.

## 3 · Python pipeline hardening
- Durable atomic writes (`fsync` temp file + directory around `os.replace`).
- Validate-time confidence cap (`@model_validator`), an optional sync wall-clock budget (`--max-runtime-minutes`), `Settings.validate()`, injectable batch grace, immutable alias map, Data Version coerced on load, audit log before overwrite. +14 tests.

## 4 · CI
- All actions **SHA-pinned**, least-privilege `permissions`, concurrency cancellation, pip caching.
- New **e2e job**: build → preview → Playwright smoke + `@axe-core/playwright` WCAG-AA in light and dark.
- **Dependabot** (npm / pip / actions). `update-data.yml` gets concurrency + a branch-scoped push gated on `github.ref == main`.

## 5 · Frontend architecture refactor
Brought the frontend to the backend's level of deliberate structure:
- **`state/interactions.ts`** — a single-writer orchestrator (the "Service" analogue); every invariant-bearing transition is a named intent.
- **`mainView` FSM** — one `'map' | 'scatter' | 'comparison'` field replaces two booleans that could both be true; mutual exclusion is now automatic.
- **Broke the `map/renderer ↔ comparison/index` import cycle** by extracting `comparison/colorSlots.ts` and having the map paint its own comparison markers.
- **`state/selectors.ts`** — memoized derived reads (`maturityRank` derives once per data load instead of an O(n²) rebuild per panel render).
- **`dom.ts`** — typed `el<T>()`/`maybeEl<T>()` replacing the unchecked `getElementById(...) as HTML*` casts.
- Typed event bus; new FSM/selector tests; **`src/ARCHITECTURE.md`** (pattern write-up + mermaid diagrams), linked from CLAUDE.md.

### Scope notes
- `dom.ts` intentionally converts the unsafe *casts* and establishes the seam; the remaining non-null `getElementById(...)!` sites are documented as an incremental migration, not churned in a risky sweep.
- Rendering stays imperative D3 by design (matches the project ethos / small bundle).

### Verified manually in headless Chromium
1366 / 1440 / 1920 / 2560 across light + dark: search (incl. no-results and full-text mentions), country panel, 2–4-country comparison, scatter, filter + blocs, timeline, cite/export, help dialog, error/empty states.

### Could not verify
Real screen-reader output on JAWS/NVDA/VoiceOver, true high-DPI/ultrawide hardware, and behaviour behind the production CSP (tests ran against `vite preview`, single-browser Chromium by design).

## Commits
1. `refactor(state)` — emit guard, deep-readonly state, data-boundary validation, coalesced renders
2. `fix(ux,a11y)` — AA contrast, search Enter, double empty-state, cite focus, scatter key
3. `harden(pipeline)` — durable writes, validate-time confidence cap, run budget, config/alias guards
4. `ci` — hardened workflows, e2e + a11y gate, Dependabot; dark-theme contrast & link fixes
5. `test` — store emit guard + loader validation
6. `refactor(arch)` — mainView FSM + interactions orchestrator, break the map↔comparison cycle
7. `refactor(state)` — memoized selectors layer + fully typed event bus
8. `refactor(dom)` — typed element accessors
9. `docs(arch)` — src/ARCHITECTURE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)